### PR TITLE
Implement midiMessage timestamp in events.

### DIFF
--- a/docs/spessa-synth-sequencer/event-types.md
+++ b/docs/spessa-synth-sequencer/event-types.md
@@ -13,6 +13,8 @@ The lists list properties of the object.
 Called when a MIDI message is sent and externalMIDIPlayback is true.
 
 - message: number[] - the binary MIDI message
+- time: number - the synthesizer's current time when this event was sent.
+Use this for scheduling MIDI messages to your external MIDI device.
 
 ### timeChange
 

--- a/src/sequencer/sequencer.ts
+++ b/src/sequencer/sequencer.ts
@@ -421,7 +421,10 @@ export class SpessaSynthSequencer {
             );
             return;
         }
-        this.callEvent("midiMessage", { message });
+        this.callEvent("midiMessage", {
+            message,
+            time: this.synth.currentSynthTime
+        });
     }
 
     protected sendMIDIAllOff() {

--- a/src/sequencer/types.ts
+++ b/src/sequencer/types.ts
@@ -10,6 +10,12 @@ export interface SequencerEventData {
          * The binary MIDI message.
          */
         message: Iterable<number>;
+
+        /**
+         * The synthesizer's current time when this event was sent.
+         * Use this for scheduling MIDI messages to your external MIDI device.
+         */
+        time: number;
     };
     /**
      * Called when the time is changed.


### PR DESCRIPTION
This PR introduces synthesizer's timestamps to the MIDI events to avoid quantization.

Fixes https://github.com/spessasus/spessasynth_core/issues/28