### PR TITLE
switch to fs/promises for examples

### DIFF
--- a/examples/dls_to_sf2.ts
+++ b/examples/dls_to_sf2.ts
@@ -1,5 +1,5 @@
 // Process arguments
-import * as fs from "node:fs";
+import * as fs from "fs/promises";
 import { BasicSoundBank, SoundBankLoader } from "../src";
 
 const args = process.argv.slice(2);
@@ -12,7 +12,7 @@ const dlsPath = args[0];
 const sf2Path = args[1];
 
 await BasicSoundBank.isSF3DecoderReady;
-const dls = fs.readFileSync(dlsPath);
+const dls = await fs.readFile(dlsPath);
 console.time("Loaded in");
 const bank = SoundBankLoader.fromArrayBuffer(dls.buffer);
 console.timeEnd("Loaded in");
@@ -21,6 +21,5 @@ console.info(`Name: ${bank.soundBankInfo.name}`);
 const outSF2 = await bank.writeSF2();
 console.timeEnd("Converted in");
 console.info(`Writing file...`);
-fs.writeFile(sf2Path, new Uint8Array(outSF2), () => {
-    console.info(`File written to ${sf2Path}`);
-});
+await fs.writeFile(sf2Path, new Uint8Array(outSF2));
+console.info(`File written to ${sf2Path}`);

--- a/examples/extract_first_sample_as_wav.ts
+++ b/examples/extract_first_sample_as_wav.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs";
+import * as fs from "fs/promises";
 import { audioToWav, SoundBankLoader } from "../src";
 
 // process arguments
@@ -9,10 +9,10 @@ if (args.length !== 2) {
 }
 
 const output = args[1];
-const file = fs.readFileSync(args[0]);
+const file = await fs.readFile(args[0]);
 const bank = SoundBankLoader.fromArrayBuffer(file.buffer);
 const sample = bank.samples[0];
 console.info("Exporting sample:", sample.name, "...");
 const wav = audioToWav([sample.getAudioData()], sample.sampleRate);
-fs.writeFileSync(output, new Uint8Array(wav));
-console.info("Done!");
+await fs.writeFile(output, new Uint8Array(wav));
+console.info(`File written to ${output}`);

--- a/examples/midi_to_wav_node.ts
+++ b/examples/midi_to_wav_node.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs";
+import * as fs from "fs/promises";
 import {
     audioToWav,
     BasicMIDI,
@@ -15,8 +15,8 @@ if (args.length !== 3) {
     );
     process.exit();
 }
-const sf = fs.readFileSync(args[0]);
-const mid = fs.readFileSync(args[1]);
+const sf = await fs.readFile(args[0]);
+const mid = await fs.readFile(args[1]);
 const midi = BasicMIDI.fromArrayBuffer(mid.buffer);
 const sampleRate = 44100;
 const sampleCount = Math.ceil(44100 * (midi.duration + 2));
@@ -67,6 +67,5 @@ console.info(
     `ms (${Math.floor(((midi.duration * 1000) / rendered) * 100) / 100}x)`
 );
 const wave = audioToWav([outLeft, outRight], sampleRate);
-fs.writeFile(args[2], new Uint8Array(wave), () => {
-    console.info(`File written to ${args[2]}`);
-});
+await fs.writeFile(args[2], new Uint8Array(wave));
+console.info(`File written to ${args[2]}`);

--- a/examples/print_bank_info.ts
+++ b/examples/print_bank_info.ts
@@ -1,5 +1,5 @@
 // Process arguments
-import * as fs from "fs";
+import * as fs from "fs/promises";
 import { BasicSoundBank, type SF2VersionTag, SoundBankLoader } from "../src";
 
 const args = process.argv.slice(2);
@@ -9,7 +9,7 @@ if (args.length !== 1) {
 }
 
 const filePath = args[0];
-const file = fs.readFileSync(filePath);
+const file = await fs.readFile(filePath);
 await BasicSoundBank.isSF3DecoderReady;
 const bank = SoundBankLoader.fromArrayBuffer(file.buffer);
 console.info("Loaded bank:", bank.soundBankInfo.name);

--- a/examples/rmid_writer.ts
+++ b/examples/rmid_writer.ts
@@ -1,5 +1,5 @@
 // Process arguments
-import * as fs from "fs";
+import * as fs from "fs/promises";
 import {
     BasicMIDI,
     BasicSoundBank,
@@ -25,8 +25,10 @@ await BasicSoundBank.isSF3DecoderReady;
 SpessaSynthLogging(true, true, true);
 
 // Load bank and MIDI
-const bank = SoundBankLoader.fromArrayBuffer(fs.readFileSync(sfPath).buffer);
-const midi = BasicMIDI.fromArrayBuffer(fs.readFileSync(midPath).buffer);
+const bank = SoundBankLoader.fromArrayBuffer(
+    (await fs.readFile(sfPath)).buffer
+);
+const midi = BasicMIDI.fromArrayBuffer((await fs.readFile(midPath)).buffer);
 console.info("Loaded bank and MIDI!");
 
 // Trim sf2 for midi
@@ -36,6 +38,5 @@ bank.trimSoundBank(midi);
 const rmidi = midi.writeRMIDI(await bank.writeSF2(), {
     soundBank: bank
 });
-fs.writeFile(outPath, new Uint8Array(rmidi), () => {
-    console.info(`File written to ${outPath}`);
-});
+await fs.writeFile(outPath, new Uint8Array(rmidi));
+console.info(`File written to ${outPath}`);

--- a/examples/sf2_to_dls.ts
+++ b/examples/sf2_to_dls.ts
@@ -1,5 +1,5 @@
 // Process arguments
-import * as fs from "fs";
+import * as fs from "fs/promises";
 import { BasicSoundBank, SoundBankLoader } from "../src";
 
 const args = process.argv.slice(2);
@@ -13,7 +13,7 @@ const dlsPath = args[1];
 
 await BasicSoundBank.isSF3DecoderReady;
 console.warn("DLS conversion may lose data.");
-const sf2 = fs.readFileSync(sf2Path);
+const sf2 = await fs.readFile(sf2Path);
 console.time("Loaded in");
 const bank = SoundBankLoader.fromArrayBuffer(sf2.buffer);
 console.timeEnd("Loaded in");
@@ -21,6 +21,5 @@ console.time("Converted in");
 const outDLS = await bank.writeDLS();
 console.timeEnd("Converted in");
 console.info(`Writing file...`);
-fs.writeFile(dlsPath, new Uint8Array(outDLS), () => {
-    console.info(`File written to ${dlsPath}`);
-});
+await fs.writeFile(dlsPath, new Uint8Array(outDLS));
+console.info(`File written to ${dlsPath}`);


### PR DESCRIPTION
This pr switches all remaining examples that used `fs` to use `fs/promises` to fix https://github.com/spessasus/spessasynth_core/issues/30

Fixes https://github.com/spessasus/spessasynth_core/issues/30