### PR TITLE
Remove unneeded meta event check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "spessasynth_core",
-    "version": "4.0.20",
+    "version": "4.0.21",
     "description": "MIDI and SoundFont2/DLS library with no compromises",
     "type": "module",
     "main": "dist/index.js",

--- a/src/midi/midi_tools/midi_builder.ts
+++ b/src/midi/midi_tools/midi_builder.ts
@@ -129,14 +129,7 @@ export class MIDIBuilder extends BasicMIDI {
                 `Track ${track} does not exist. Add it via addTrack method.`
             );
         }
-        if (event < midiMessageTypes.noteOff) {
-            // Meta event
-            if (track > 0) {
-                throw new Error(
-                    `Meta events must be added to the first track, not track ${track}.`
-                );
-            }
-        } else {
+        if (event >= midiMessageTypes.noteOff) {
             // Voice event
             if (this.format === 1 && track === 0) {
                 throw new Error(

--- a/tests/midi_creation_test.ts
+++ b/tests/midi_creation_test.ts
@@ -1,0 +1,11 @@
+import { MIDIBuilder } from "../src";
+
+const mid = new MIDIBuilder({
+    format: 1
+});
+mid.addNewTrack("TEST");
+mid.addNoteOn(0, 1, 0, 64, 120);
+mid.addNoteOff(200, 1, 0, 64);
+mid.flush();
+mid.writeMIDI();
+console.info("Succesfully created a simple test file");


### PR DESCRIPTION
This PR removes an unneeded meta event check that also broke the `addNewTrack` method.
It also adds a simple test file.

Fixes https://github.com/spessasus/spessasynth_core/issues/31