### PR TITLE
Introduce the soft loop type

### DIFF
--- a/docs/midi/index.md
+++ b/docs/midi/index.md
@@ -112,6 +112,24 @@ The points of the loop detected in the MIDI file in ticks.
 If there's nothing detected, the loop will start from the first note on event and end will be the last voice message.
 Current looping detection is: CC 2/4, 116/117 and "start," "loopStart" and "loopEnd" markers.
 
+#### start
+
+The start of the loop, in MIDI ticks.
+
+#### end
+
+The end of the loop, in MIDI ticks.
+
+#### type
+
+The type of the loop detected:
+
+- `soft` - the playback will immediately jump to the loop start pointer without any further processing.
+- `hard` - the playback will quickly process all messages from
+the start of the file to ensure that synthesizer is in the correct state.
+This is the default behavior.
+
+Soft loop types are enabled by default for Touhou and GameMaker loop points.
 
 ### fileName
 

--- a/src/midi/basic_midi.ts
+++ b/src/midi/basic_midi.ts
@@ -15,6 +15,7 @@ import type {
     DesiredProgramChange,
     MIDIFormat,
     MIDILoop,
+    MIDILoopType,
     NoteTime,
     RMIDInfoData,
     RMIDIWriteOptions,
@@ -91,7 +92,7 @@ export class BasicMIDI {
     /**
      * The loop points (in ticks) of the sequence, including both start and end points.
      */
-    public loop: MIDILoop = { start: 0, end: 0 };
+    public loop: MIDILoop = { start: 0, end: 0, type: "hard" };
 
     /**
      * The file name of the MIDI sequence, if provided during parsing.
@@ -570,7 +571,7 @@ export class BasicMIDI {
         this.keyRange = { max: 0, min: 127 };
         this.lastVoiceEventTick = 0;
         this.portChannelOffsetMap = [0];
-        this.loop = { start: 0, end: 0 };
+        this.loop = { start: 0, end: 0, type: "hard" };
         // Do not reset RMIDI info (parsed in MIDI loader)
         // Do not reset bank offset (parsed in MIDI loader)
         this.isKaraokeFile = false;
@@ -585,6 +586,7 @@ export class BasicMIDI {
         // Loop tracking
         let loopStart = null;
         let loopEnd = null;
+        let loopType: MIDILoopType = "hard";
 
         for (const track of this.tracks) {
             const usedChannels = new Set<number>();
@@ -619,6 +621,7 @@ export class BasicMIDI {
                                 // EMIDI/XMI
                                 case 117:
                                     if (loopEnd === null) {
+                                        loopType = "soft";
                                         loopEnd = e.ticks;
                                     } else {
                                         // This controller has occurred more than once;
@@ -820,7 +823,7 @@ export class BasicMIDI {
             loopEnd = this.lastVoiceEventTick;
         }
 
-        this.loop = { start: loopStart, end: loopEnd };
+        this.loop = { start: loopStart, end: loopEnd, type: loopType };
 
         SpessaSynthInfo(
             `%cLoop points: start: %c${this.loop.start}%c end: %c${this.loop.end}`,

--- a/src/midi/types.ts
+++ b/src/midi/types.ts
@@ -82,6 +82,8 @@ export interface TempoChange {
     tempo: number;
 }
 
+export type MIDILoopType = "soft" | "hard";
+
 export interface MIDILoop {
     /**
      * Start of the loop, in MIDI ticks.
@@ -91,6 +93,17 @@ export interface MIDILoop {
      * End of the loop, in MIDI ticks.
      */
     end: number;
+
+    /**
+     * The type of the loop detected:
+     * - Soft - the playback will immediately jump to the loop start pointer without any further processing.
+     * - Hard - the playback will quickly process all messages from
+     * the start of the file to ensure that synthesizer is in the correct state.
+     * This is the default behavior.
+     *
+     * Soft loop types are enabled for Touhou and GameMaker loop points.
+     */
+    type: MIDILoopType;
 }
 
 export type MIDIFormat = 0 | 1 | 2;

--- a/src/sequencer/process_tick.ts
+++ b/src/sequencer/process_tick.ts
@@ -27,7 +27,11 @@ export function processTick(this: SpessaSynthSequencer) {
                     newCount: this.loopCount
                 });
             }
-            this.setTimeTicks(this._midiData.loop.start);
+            if (this._midiData.loop.type === "soft") {
+                this.jumpToTick(this._midiData.loop.start);
+            } else {
+                this.setTimeTicks(this._midiData.loop.start);
+            }
             return;
         }
         // Check for end of track

--- a/src/utils/exports.ts
+++ b/src/utils/exports.ts
@@ -15,7 +15,6 @@ import {
     SpessaSynthLogging,
     SpessaSynthWarn
 } from "./loggin";
-import type { MIDILoop } from "../midi/types";
 
 import type { FourCC } from "./riff_chunk";
 
@@ -59,7 +58,16 @@ export interface WaveWriteOptions {
     /**
      * The loop start and end points in seconds. Undefined if no loop should be written.
      */
-    loop?: MIDILoop;
+    loop?: {
+        /**
+         * The start point in seconds.
+         */
+        start: number;
+        /**
+         * The end point in seconds.
+         */
+        end: number;
+    };
     /**
      * The metadata to write into the file.
      */


### PR DESCRIPTION
This PR introduces the `soft` loop type. This loop type causes the sequencer to jump to the start of the loop without any processing of the previous events and is only enabled for Touhou and GameMaker loops, fixing files such as `紅楼　～ Eastern Dream` while improving the seamlessness of these loops.