### PR TITLE
Disable vibrato if the modulation wheel is enabled

### DIFF
--- a/docs/extra/midi-implementation.md
+++ b/docs/extra/midi-implementation.md
@@ -141,7 +141,11 @@ After which any changes received through the NRPN (including the one that trigge
 This behavior has existed since the beginning of this program as a way to enhance the TH MIDI files,
 the original target of SpessaSynth.
 
-[It can be disabled.](https://github.com/spessasus/spessasynth_lib/blob/b0716295820fc6b2e8873a1b0871ca6a0266ea02/src/synthetizer/worklet_processor.js#L281-L292)
+**It is disabled for any channel that has CC#1 (Mod Wheel) set to anything other than 0.**
+This can be useful as setting CC#1 to something like 1 (which is usually imperceptible), 
+will fully disable the extra vibrato.
+
+[Custom vibrato can be fully disabled as well.](https://github.com/spessasus/spessasynth_lib/blob/b0716295820fc6b2e8873a1b0871ca6a0266ea02/src/synthetizer/worklet_processor.js#L281-L292)
 
 #### SoundFont2 NRPN
 

--- a/src/synthesizer/audio_engine/engine_components/dsp_chain/render_voice.ts
+++ b/src/synthesizer/audio_engine/engine_components/dsp_chain/render_voice.ts
@@ -8,6 +8,7 @@ import type { Voice } from "../voice";
 import type { MIDIChannel } from "../midi_channel";
 import { generatorTypes } from "../../../../soundbank/basic_soundbank/generator_types";
 import { customControllers } from "../../../enums";
+import { midiControllers } from "../../../../midi/enums";
 
 /**
  * Renders a voice to the stereo output buffer
@@ -161,16 +162,18 @@ export function renderVoice(
     }
 
     // Channel vibrato (GS NRPN)
-    if (this.channelVibrato.depth > 0) {
+    if (
+        // Only enabled when modulation wheel is disabled (to prevent overlap)
+        this.midiControllers[midiControllers.modulationWheel] == 0 &&
+        this.channelVibrato.depth > 0
+    ) {
         // Same as others
-        const channelVibrato = getLFOValue(
-            voice.startTime + this.channelVibrato.delay,
-            this.channelVibrato.rate,
-            timeNow
-        );
-        if (channelVibrato) {
-            cents += channelVibrato * this.channelVibrato.depth;
-        }
+        cents +=
+            getLFOValue(
+                voice.startTime + this.channelVibrato.delay,
+                this.channelVibrato.rate,
+                timeNow
+            ) * this.channelVibrato.depth;
     }
 
     // Mod env


### PR DESCRIPTION
This simple PR disables custom vibrato if CC1 is set to anything other than 0, making them not conflict with each other as well as adding a simple way to disable it per channel.

It also documents those changes.