### PR TITLE
Implement secondsToMIDITicks

### DIFF
--- a/docs/midi/index.md
+++ b/docs/midi/index.md
@@ -240,6 +240,20 @@ midi.midiTicksToSeconds(ticks);
 
 The returned value is the time in seconds from the start of the MIDI to the given tick.
 
+
+### secondsToMIDITicks
+
+Calculates time in MIDI ticks given seconds.
+
+```ts
+midi.secondsToMIDITicks(seconds);
+```
+
+- seconds - `number` - the time in seconds.
+
+The returned value is the time in MIDI ticks from the start of the MIDI to the given second.
+Note that the returned value will always be rounded to the nearest integer.
+
 ### getUsedProgramsAndKeys
 
 Goes through the MIDI file and returns all used program numbers and MIDI key:velocity combinations for them,

--- a/tests/seconds_ticks_conversion_test.ts
+++ b/tests/seconds_ticks_conversion_test.ts
@@ -1,0 +1,26 @@
+// Process arguments
+import * as fs from "node:fs/promises";
+import { BasicMIDI } from "../src";
+
+const args = process.argv.slice(2);
+if (args.length !== 1) {
+    console.info("Usage: tsx index.ts<midi path>");
+    process.exit();
+}
+const midPath = args[0];
+
+const m = await fs.readFile(midPath);
+const mid = BasicMIDI.fromArrayBuffer(m.buffer as ArrayBuffer);
+
+const loopEnd = mid.loop.end;
+const loopEndSeconds = mid.midiTicksToSeconds(loopEnd);
+const loopEndTicks2 = mid.secondsToMIDITicks(loopEndSeconds);
+console.info("Loop end in ticks:", loopEnd);
+console.info("Loop end in seconds:", loopEndSeconds);
+if (loopEndTicks2 !== loopEnd) {
+    throw new Error(
+        `Test failed!, ticks -> seconds -> ticks resulted in ${loopEndTicks2} instead of ${loopEnd}`
+    );
+} else {
+    console.info("Test passed! Ticks match.", loopEndTicks2, loopEnd);
+}


### PR DESCRIPTION
This PR implements `secondsToMIDITicks`, an inverse of the `midiTicksToSeconds` method.

It also adds a simple test script and documents the new method.

Resolves #39