### PR TITLE
perf: improve volume envelope

### DIFF
--- a/src/synthesizer/audio_engine/engine_components/dsp_chain/volume_envelope.ts
+++ b/src/synthesizer/audio_engine/engine_components/dsp_chain/volume_envelope.ts
@@ -108,8 +108,6 @@ export class VolumeEnvelope {
         this.gainSmoothing = GAIN_SMOOTHING_FACTOR * (44_100 / sampleRate);
     }
 
-
-
     /**
      * Applies volume envelope gain to the given output buffer.
      * Essentially we use approach of 100dB is silence, 0dB is peak.
@@ -127,28 +125,63 @@ export class VolumeEnvelope {
     ): boolean {
         // RELEASE PHASE
         if (this.enteredRelease) {
-            return this.releasePhase(sampleCount, buffer, gainTarget, centibelOffset);
+            return this.releasePhase(
+                sampleCount,
+                buffer,
+                gainTarget,
+                centibelOffset
+            );
         }
 
         switch (this.state) {
             case 0: {
-                return this.delayPhase(sampleCount, buffer, gainTarget, centibelOffset, 0);
+                return this.delayPhase(
+                    sampleCount,
+                    buffer,
+                    gainTarget,
+                    centibelOffset,
+                    0
+                );
             }
 
             case 1: {
-                return this.attackPhase(sampleCount, buffer, gainTarget, centibelOffset, 0);
+                return this.attackPhase(
+                    sampleCount,
+                    buffer,
+                    gainTarget,
+                    centibelOffset,
+                    0
+                );
             }
 
             case 2: {
-                return this.holdPhase(sampleCount, buffer, gainTarget, centibelOffset, 0);
+                return this.holdPhase(
+                    sampleCount,
+                    buffer,
+                    gainTarget,
+                    centibelOffset,
+                    0
+                );
             }
 
             case 3: {
-                return this.decayPhase(sampleCount, buffer, gainTarget, centibelOffset, 0);
+                return this.decayPhase(
+                    sampleCount,
+                    buffer,
+                    gainTarget,
+                    centibelOffset,
+                    0
+                );
             }
 
             case 4: {
-                return this.sustainPhase(sampleCount, buffer, gainTarget, centibelOffset, 0);
+                return this.sustainPhase(
+                    sampleCount,
+                    buffer,
+                    gainTarget,
+                    centibelOffset,
+                    0
+                );
             }
         }
     }
@@ -191,7 +224,7 @@ export class VolumeEnvelope {
             this.decayDuration =
                 this.timecentsToSamples(
                     voice.modulatedGenerators[generatorTypes.decayVolEnv] +
-                    keyNumAddition
+                        keyNumAddition
                 ) * fraction;
 
             switch (this.state) {
@@ -209,7 +242,7 @@ export class VolumeEnvelope {
                     const elapsed =
                         1 -
                         (this.attackEnd - this.releaseStartTimeSamples) /
-                        this.attackDuration;
+                            this.attackDuration;
                     // Calculate the gain that the attack would have, so
                     // Turn that into cB
                     this.releaseStartCb = 200 * Math.log10(elapsed) * -1;
@@ -225,7 +258,7 @@ export class VolumeEnvelope {
                     this.releaseStartCb =
                         (1 -
                             (this.decayEnd - this.releaseStartTimeSamples) /
-                            this.decayDuration) *
+                                this.decayDuration) *
                         sustainCb;
                     break;
                 }
@@ -293,7 +326,7 @@ export class VolumeEnvelope {
         this.decayDuration =
             this.timecentsToSamples(
                 voice.modulatedGenerators[generatorTypes.decayVolEnv] +
-                keyNumAddition
+                    keyNumAddition
             ) * fraction;
 
         // Calculate absolute end times for the values
@@ -309,7 +342,7 @@ export class VolumeEnvelope {
         this.holdEnd =
             this.timecentsToSamples(
                 voice.modulatedGenerators[generatorTypes.holdVolEnv] +
-                holdExcursion
+                    holdExcursion
             ) + this.attackEnd;
 
         this.decayEnd = this.decayDuration + this.holdEnd;
@@ -328,13 +361,19 @@ export class VolumeEnvelope {
         );
     }
 
-    private releasePhase(sampleCount: number,
+    private releasePhase(
+        sampleCount: number,
         buffer: Float32Array,
         gainTarget: number,
         centibelOffset: number
     ) {
         let { sampleTime, currentGain, attenuationCb } = this;
-        const { releaseStartTimeSamples, releaseStartCb, releaseDuration, gainSmoothing } = this;
+        const {
+            releaseStartTimeSamples,
+            releaseStartCb,
+            releaseDuration,
+            gainSmoothing
+        } = this;
 
         // How much time has passed since release was started?
         let elapsedRelease = sampleTime - releaseStartTimeSamples;
@@ -369,13 +408,13 @@ export class VolumeEnvelope {
         return attenuationCb < PERCEIVED_CB_SILENCE;
     }
 
-    private delayPhase(sampleCount: number,
+    private delayPhase(
+        sampleCount: number,
         buffer: Float32Array,
         gainTarget: number,
         centibelOffset: number,
         filledBuffer: number
     ) {
-
         const { delayEnd } = this;
         let { sampleTime } = this;
 
@@ -398,16 +437,22 @@ export class VolumeEnvelope {
         this.sampleTime = sampleTime;
         this.state++;
 
-        return this.attackPhase(sampleCount, buffer, gainTarget, centibelOffset,
-            filledBuffer);
+        return this.attackPhase(
+            sampleCount,
+            buffer,
+            gainTarget,
+            centibelOffset,
+            filledBuffer
+        );
     }
 
-    private attackPhase(sampleCount: number,
+    private attackPhase(
+        sampleCount: number,
         buffer: Float32Array,
         gainTarget: number,
         centibelOffset: number,
-        filledBuffer: number) {
-
+        filledBuffer: number
+    ) {
         const { attackEnd, attackDuration, gainSmoothing } = this;
         let { sampleTime, currentGain } = this;
         const smooth = currentGain !== gainTarget;
@@ -424,9 +469,7 @@ export class VolumeEnvelope {
 
                 // Special case: linear gain ramp instead of linear db ramp
                 const linearGain =
-                    1 -
-                    (attackEnd - sampleTime) /
-                    attackDuration; // 0 to 1
+                    1 - (attackEnd - sampleTime) / attackDuration; // 0 to 1
 
                 // Apply gain to buffer
                 buffer[filledBuffer] *= linearGain * currentGain;
@@ -444,19 +487,22 @@ export class VolumeEnvelope {
         this.currentGain = currentGain;
         this.state++;
 
-        return this.holdPhase(sampleCount,
+        return this.holdPhase(
+            sampleCount,
             buffer,
             gainTarget,
             centibelOffset,
-            filledBuffer);
+            filledBuffer
+        );
     }
 
-    private holdPhase(sampleCount: number,
+    private holdPhase(
+        sampleCount: number,
         buffer: Float32Array,
         gainTarget: number,
         centibelOffset: number,
-        filledBuffer: number) {
-
+        filledBuffer: number
+    ) {
         const { holdEnd, gainSmoothing } = this;
         let { sampleTime, currentGain } = this;
         const smooth = currentGain !== gainTarget;
@@ -488,19 +534,22 @@ export class VolumeEnvelope {
         this.currentGain = currentGain;
         this.state++;
 
-        return this.decayPhase(sampleCount,
+        return this.decayPhase(
+            sampleCount,
             buffer,
             gainTarget,
             centibelOffset,
-            filledBuffer);
+            filledBuffer
+        );
     }
 
-    private decayPhase(sampleCount: number,
+    private decayPhase(
+        sampleCount: number,
         buffer: Float32Array,
         gainTarget: number,
         centibelOffset: number,
-        filledBuffer: number) {
-
+        filledBuffer: number
+    ) {
         const { decayDuration, decayEnd, gainSmoothing, sustainCb } = this;
         let { sampleTime, currentGain, attenuationCb } = this;
         const smooth = currentGain !== gainTarget;
@@ -512,14 +561,13 @@ export class VolumeEnvelope {
                     currentGain += (gainTarget - currentGain) * gainSmoothing;
                 }
                 // Linear ramp down to sustain
-                attenuationCb = (1 - (decayEnd - sampleTime) / decayDuration) * sustainCb;
+                attenuationCb =
+                    (1 - (decayEnd - sampleTime) / decayDuration) * sustainCb;
 
                 // Apply gain to buffer
                 buffer[filledBuffer] *=
                     currentGain *
-                    cbAttenuationToGain(
-                        attenuationCb + centibelOffset
-                    );
+                    cbAttenuationToGain(attenuationCb + centibelOffset);
 
                 sampleTime++;
                 if (++filledBuffer >= sampleCount) {
@@ -536,26 +584,25 @@ export class VolumeEnvelope {
         this.attenuationCb = attenuationCb;
         this.state++;
 
-        return this.sustainPhase(sampleCount,
+        return this.sustainPhase(
+            sampleCount,
             buffer,
             gainTarget,
             centibelOffset,
-            filledBuffer);
+            filledBuffer
+        );
     }
 
-
-    private sustainPhase(sampleCount: number,
+    private sustainPhase(
+        sampleCount: number,
         buffer: Float32Array,
         gainTarget: number,
         centibelOffset: number,
-        filledBuffer: number) {
-
+        filledBuffer: number
+    ) {
         const { sustainCb, gainSmoothing } = this;
 
-        if (
-            this.canEndOnSilentSustain &&
-            sustainCb >= PERCEIVED_CB_SILENCE
-        ) {
+        if (this.canEndOnSilentSustain && sustainCb >= PERCEIVED_CB_SILENCE) {
             return false;
         }
 


### PR DESCRIPTION
NOTE: this PR contributes to the `voice-pool` branch where we tackle performance optimizations

I has two improvements.

1. Using Locals 

Simply moving the voice envelope variables to method locals already brings a performance improvement.

Additionally I decided to split-up the logic into own methods in the hope that it allows the runtime to do further optimizations. 

The test_performance.ts shows:  

**Before (`voice-pool` branch) **

```
Rendering MIDI. Pass 0 / 10
Pass 0: 17845ms
Rendering MIDI. Pass 1 / 10
Pass 1: 17707ms
Rendering MIDI. Pass 2 / 10
Pass 2: 17860ms
Rendering MIDI. Pass 3 / 10
Pass 3: 17818ms
Rendering MIDI. Pass 4 / 10
Pass 4: 17777ms
Rendering MIDI. Pass 5 / 10
Pass 5: 17917ms
Rendering MIDI. Pass 6 / 10
Pass 6: 17707ms
Rendering MIDI. Pass 7 / 10
Pass 7: 17721ms
Rendering MIDI. Pass 8 / 10
Pass 8: 17793ms
Rendering MIDI. Pass 9 / 10
Pass 9: 17741ms
Average time: 17789ms
```

**After**

```
Rendering MIDI. Pass 0 / 10
Pass 0: 17361ms
Rendering MIDI. Pass 1 / 10
Pass 1: 17137ms
Rendering MIDI. Pass 2 / 10
Pass 2: 17093ms
Rendering MIDI. Pass 3 / 10
Pass 3: 17062ms
Rendering MIDI. Pass 4 / 10
Pass 4: 17087ms
Rendering MIDI. Pass 5 / 10
Pass 5: 17109ms
Rendering MIDI. Pass 6 / 10
Pass 6: 17124ms
Rendering MIDI. Pass 7 / 10
Pass 7: 17066ms
Rendering MIDI. Pass 8 / 10
Pass 8: 17074ms
Rendering MIDI. Pass 9 / 10
Pass 9: 17094ms
Average time: 17121ms
```

It's not a lot but a visible improvement. 

2. Fixing the release phase of the volume envelope. 

As commented [here](https://github.com/spessasus/spessasynth_core/issues/2#issuecomment-3806306685) I think there is a bug in the release phase of the volume envelope. Unless my understanding is wrong: It kept voices active and in the release phase if the they were not audible. 

I inverted the check and the duration is down to 7865ms (!)

I also added a check whether we reached the end of the release according to the config. Just to be sure for cases where the config doesn't ensure we ramp down to 0. Maybe that's already covered somehow, but it felt like an easy check. 

--- 

To check what changed before and after I took the raw PCM output, inverted one of them and mixed them together. From the audible result what is different, it seems to be mainly percussion related:

Difference between before and after
<img width="1682" height="299" alt="image" src="https://github.com/user-attachments/assets/4b4c708f-7e4f-49d0-a2c5-10c14559eea4" />

[difference.mp3](https://github.com/user-attachments/files/24892338/difference.mp3)

Optimized Output: 
[optimized.mp3](https://github.com/user-attachments/files/24892346/optimized.mp3)


