### PR TITLE
Consistent e-mu attenuation correction

### DIFF
--- a/src/soundbank/downloadable_sounds/wave_sample.ts
+++ b/src/soundbank/downloadable_sounds/wave_sample.ts
@@ -149,7 +149,7 @@ export class WaveSample extends DLSVerifier {
         waveSample.fineTune = zone.fineTuning + zone.sample.pitchCorrection;
         // E-mu attenuation correction
         const attenuationCb =
-            zone.getGenerator(generatorTypes.initialAttenuation, 0) * 0.4;
+            Math.floor(zone.getGenerator(generatorTypes.initialAttenuation, 0) * 0.4);
         // Gain is stored as a 32-bit value, shift here
         waveSample.gain = -attenuationCb << 16;
         const loopingMode = zone.getGenerator(

--- a/src/soundbank/downloadable_sounds/wave_sample.ts
+++ b/src/soundbank/downloadable_sounds/wave_sample.ts
@@ -210,7 +210,7 @@ export class WaveSample extends DLSVerifier {
         const wsmpGain16 = this.gain >> 16;
         const wsmpAttenuation = -wsmpGain16;
         // Apply the E-MU attenuation correction here
-        const wsmpAttenuationCorrected = wsmpAttenuation / 0.4;
+        const wsmpAttenuationCorrected = Math.floor(wsmpAttenuation / 0.4);
 
         if (wsmpAttenuationCorrected !== 0) {
             zone.setGenerator(


### PR DESCRIPTION
Make it consistent with how it is performed in BasicPreset https://github.com/spessasus/spessasynth_core/blob/master/src/soundbank/basic_soundbank/basic_preset.ts#L313

```ts
                // EMU initial attenuation correction, multiply initial attenuation by 0.4!
                // All EMU sound cards have this quirk, and all sf2 editors and players emulate it too
                generators[generatorTypes.initialAttenuation] = Math.floor(
                    generators[generatorTypes.initialAttenuation] * 0.4
                );
```