### PR TITLE
Fix writeDLS when converting CT8MGM.SF2

### DIFF
--- a/src/soundbank/basic_soundbank/basic_instrument.ts
+++ b/src/soundbank/basic_soundbank/basic_instrument.ts
@@ -254,10 +254,9 @@ export class BasicInstrument {
         }
 
         // Globalize only modulators that exist in all zones
-        const firstZone = this.zones[0];
-        const modulators = firstZone.modulators.map((m) =>
-            Modulator.copyFrom(m)
-        );
+        const modulators = this.zones.length === 0 
+            ? []
+            : this.zones[0].modulators.map((m) => Modulator.copyFrom(m));
         for (const checkedModulator of modulators) {
             let existsForAllZones = true;
             for (const zone of this.zones) {

--- a/src/soundbank/basic_soundbank/basic_preset.ts
+++ b/src/soundbank/basic_soundbank/basic_preset.ts
@@ -504,8 +504,8 @@ export class BasicPreset implements MIDIPatchNamed {
                         g.generatorType !== generatorTypes.velRange &&
                         g.generatorType !== generatorTypes.endOper &&
                         g.generatorType !== generatorTypes.instrument &&
-                        g.generatorValue !==
-                            generatorLimits[g.generatorType].def
+                        (!(g.generatorType in generatorLimits) ||
+                         g.generatorValue !== generatorLimits[g.generatorType].def)
                 );
 
                 // Create the zone and copy over values


### PR DESCRIPTION
Fixes two issues:
- Access generatorLimits.def when the key doesn't exist inside `toFlattenedInstrument`.
- Access this.zones[0] when the array is empty in `globalize`
You can find the sf here https://sembiance.com/fileFormatSamples/audio/soundFont2/