### PR TITLE
Add RF64 SFE Support

### DIFF
--- a/docs/sound-bank/index.md
+++ b/docs/sound-bank/index.md
@@ -2,7 +2,7 @@
 
 This module handles parsing and writing SoundFont2 (`.sf2`, `.sf3` and `.sfogg`) files.
 
-It also contains support for `.dls` files.
+It also contains support for `.dls` files and experimental read support for [64-bit SFE](https://github.com/SFe-Team-was-taken/SFE)
 
 !!! Tip
 

--- a/docs/sound-bank/index.md
+++ b/docs/sound-bank/index.md
@@ -275,6 +275,30 @@ const binary = soundBank.writeSF2(options);
 
     This method is memory and CPU intensive with large sound banks, especially if compression is enabled.
 
+### writeSFE
+
+Writes the sound bank as an [SFE 4](https://sfe-team-was-taken.github.io/SFE/) file.
+This enables features such as bank LSB and RIFF64.
+
+!!! Note
+
+    Spessasynth is currently the only software that can read these files.
+
+```ts
+const binary = soundBank.writeSFE(options);
+```
+
+- `options` - An optional object (all properties are optional):
+    - `progressFunction` - [See this for a detailed explanation](#progressfunction)
+    - `software` - A `string`, the `ISFT` field to set when writing. If unset, "SpessaSynth" is written.
+      This field indicates the last software that was used to edit this sound bank.
+    - `rf64` - If the RIFS (64-bit RIFF chunks) should be used. Increases maximum size from 4GB to effectively infinite.
+      Recommended, since SFE 4 is effectively incompatible with SF2.
+
+!!! Warning
+
+    This method is memory and CPU intensive with large sound banks, especially if compression is enabled.
+
 ### addPresets
 
 Adds presets to the sound bank.

--- a/scripts/install_examples.ts
+++ b/scripts/install_examples.ts
@@ -18,7 +18,7 @@ const pkg = {
     keywords: [],
     author: "",
     license: "ISC",
-    type: "commonjs",
+    type: "module",
     dependencies: {
         midi: "^2.0.0",
         speaker: "^0.5.5"

--- a/src/midi/read/rmidi.ts
+++ b/src/midi/read/rmidi.ts
@@ -44,7 +44,7 @@ export function parseRMIDIInternal(
     // Keep loading chunks until we get the "SFBK" header
     while (binaryData.currentIndex < binaryData.length) {
         const startIndex = binaryData.currentIndex;
-        const currentChunk = RIFFChunk.read(binaryData, true);
+        const currentChunk = RIFFChunk.read(binaryData);
         if (currentChunk.header === "RIFF") {
             const type = readBinaryStringIndexed(
                 currentChunk.data,
@@ -76,7 +76,7 @@ export function parseRMIDIInternal(
                     ConsoleColors.recognized
                 );
                 while (currentChunk.data.currentIndex < currentChunk.size) {
-                    const infoChunk = RIFFChunk.read(currentChunk.data, true);
+                    const infoChunk = RIFFChunk.read(currentChunk.data);
                     const headerTyped = infoChunk.header as RMIDInfoFourCC;
                     const infoData = infoChunk.data;
                     switch (headerTyped) {

--- a/src/midi/write/rmidi.ts
+++ b/src/midi/write/rmidi.ts
@@ -449,7 +449,7 @@ export function writeRMIDIInternal(
     return RIFFChunk.writeParts("RIFF", [
         getStringBytes("RMID"),
         RIFFChunk.write("data", newMid),
-        RIFFChunk.writeParts("INFO", infoContent, true),
+        RIFFChunk.writeParts("INFO", infoContent, false, true),
         new IndexedByteArray(soundBankBinary)
     ]).buffer;
 }

--- a/src/soundbank/basic_soundbank/basic_instrument.ts
+++ b/src/soundbank/basic_soundbank/basic_instrument.ts
@@ -301,6 +301,11 @@ export class BasicInstrument {
         }
     }
 
+    /**
+     * @internal
+     * @param instData
+     * @param index
+     */
     public write(instData: ExtendedSF2Chunks, index: number) {
         SpessaLog.info(`%cWriting ${this.name}...`, ConsoleColors.info);
         // Split up the name

--- a/src/soundbank/basic_soundbank/basic_preset.ts
+++ b/src/soundbank/basic_soundbank/basic_preset.ts
@@ -519,8 +519,14 @@ export class BasicPreset implements MIDIPatchFull {
      * Writes the SF2 header
      * @param phdrData
      * @param index
+     * @param writeLSB
+     * @internal
      */
-    public write(phdrData: ExtendedSF2Chunks, index: number) {
+    public write(
+        phdrData: ExtendedSF2Chunks,
+        index: number,
+        writeLSB: boolean
+    ) {
         SpessaLog.info(`%cWriting ${this.name}...`, ConsoleColors.info);
         // Split up the name
         writeBinaryStringIndexed(phdrData.pdta, this.name.slice(0, 20), 20);
@@ -528,12 +534,20 @@ export class BasicPreset implements MIDIPatchFull {
 
         writeWord(phdrData.pdta, this.program);
         let wBank = this.bankMSB;
-        if (this.isGMGSDrum) {
-            // Drum flag
-            wBank = 0x80;
-        } else if (this.bankMSB === 0) {
-            // If bank MSB is zero, write bank LSB (XG)
-            wBank = this.bankLSB;
+        if (writeLSB) {
+            wBank = (this.bankMSB & 0x7f) | ((this.bankLSB & 0x7f) << 8);
+            if (this.isGMGSDrum) {
+                // Drum flag
+                wBank |= 0x80;
+            }
+        } else {
+            if (this.isGMGSDrum) {
+                // Drum flag
+                wBank = 0x80;
+            } else if (this.bankMSB === 0) {
+                // If bank MSB is zero, write bank LSB (XG)
+                wBank = this.bankLSB;
+            }
         }
         writeWord(phdrData.pdta, wBank);
         // Skip wBank and wProgram

--- a/src/soundbank/basic_soundbank/basic_soundbank.ts
+++ b/src/soundbank/basic_soundbank/basic_soundbank.ts
@@ -2,7 +2,9 @@ import { SpessaLog } from "../../utils/loggin";
 import { ConsoleColors } from "../../utils/other";
 import {
     DEFAULT_SF2_WRITE_OPTIONS,
-    writeSF2Internal
+    DEFAULT_SFE_WRITE_OPTIONS,
+    writeSF2Internal,
+    writeSFEInternal
 } from "../soundfont/write/write";
 import { Modulator, SPESSASYNTH_DEFAULT_MODULATORS } from "./modulator";
 import { BasicSample, EmptySample } from "./basic_sample";
@@ -17,6 +19,7 @@ import type {
     PresetsWithKeyCombinations,
     SetSampleFormatOptions,
     SF2VersionTag,
+    SFEWriteOptions,
     SoundBankInfoData,
     SoundFont2WriteOptions
 } from "../types";
@@ -39,12 +42,12 @@ export class BasicSoundBank {
 
     /**
      * The type of the sound bank that was loaded.
-     * Either `sf2` for SoundFont2/SoundFont3 or `dls` for DownLoadable Sounds.
+     * Either `sf2` for SoundFont2/SoundFont3 or `dls` for DownLoadable Sounds or `sfe` for SF-Enhanced.
      *
      * Please note that SF3 or SFOGG files are parsed as `sf2` files, but with compressed samples.
      * The type is still `sf2`.
      */
-    public readonly type: "sf2" | "dls";
+    public readonly type: "sf2" | "dls" | "sfe";
 
     /**
      * Sound bank's info.
@@ -87,7 +90,7 @@ export class BasicSoundBank {
      */
     public customDefaultModulators = false;
 
-    public constructor(type: "sf2" | "dls" = "sf2") {
+    public constructor(type: "sf2" | "sfe" | "dls" = "sf2") {
         this.type = type;
     }
 
@@ -309,6 +312,19 @@ export class BasicSoundBank {
         writeOptions: Partial<SoundFont2WriteOptions> = DEFAULT_SF2_WRITE_OPTIONS
     ) {
         return writeSF2Internal(this, writeOptions);
+    }
+
+    /**
+     * Writes the sound bank as an [SFE 4](https://sfe-team-was-taken.github.io/SFE/) file.
+     * This enables features such as bank LSB and RIFF64.
+     * Note that spessasynth is currently the only software that can read these files.
+     * @param writeOptions the options for writing.
+     * @returns the binary file data.
+     */
+    public writeSFE(
+        writeOptions: Partial<SFEWriteOptions> = DEFAULT_SFE_WRITE_OPTIONS
+    ) {
+        return writeSFEInternal(this, writeOptions);
     }
 
     public addPresets(...presets: BasicPreset[]) {

--- a/src/soundbank/downloadable_sounds/downloadable_sounds.ts
+++ b/src/soundbank/downloadable_sounds/downloadable_sounds.ts
@@ -363,6 +363,7 @@ export class DownloadableSounds extends DLSVerifier {
         const lins = RIFFChunk.getParts(
             "lins",
             this.instruments.map((i) => i.write()),
+            false,
             true
         );
         SpessaLog.info("%cSuccess!", ConsoleColors.recognized);
@@ -392,7 +393,7 @@ export class DownloadableSounds extends DLSVerifier {
             samples.push(...out);
             written++;
         }
-        const wvpl = RIFFChunk.getParts("wvpl", samples, true);
+        const wvpl = RIFFChunk.getParts("wvpl", samples, false, true);
         SpessaLog.info("%cSucceeded!", ConsoleColors.recognized);
 
         // Write ptbl
@@ -431,7 +432,7 @@ export class DownloadableSounds extends DLSVerifier {
             ...lins,
             ptbl,
             ...wvpl,
-            ...RIFFChunk.getParts("INFO", infos, true)
+            ...RIFFChunk.getParts("INFO", infos, false, true)
         ]);
 
         SpessaLog.info("%cSaved successfully!", ConsoleColors.recognized);

--- a/src/soundbank/downloadable_sounds/downloadable_sounds.ts
+++ b/src/soundbank/downloadable_sounds/downloadable_sounds.ts
@@ -53,7 +53,7 @@ export class DownloadableSounds extends DLSVerifier {
         SpessaLog.group("%cParsing DLS file...", ConsoleColors.info);
 
         // Read the main chunk
-        const firstChunk = RIFFChunk.read(dataArray, false);
+        const firstChunk = RIFFChunk.read(dataArray, false, false);
         this.verifyHeader(firstChunk, "RIFF");
         this.verifyText(
             readBinaryStringIndexed(dataArray, 4).toLowerCase(),

--- a/src/soundbank/downloadable_sounds/instrument.ts
+++ b/src/soundbank/downloadable_sounds/instrument.ts
@@ -186,7 +186,7 @@ export class DownloadableSoundsInstrument
         const chunks: Uint8Array[] = [this.writeHeader()];
 
         const regionChunks = this.regions.flatMap((r) => r.write());
-        chunks.push(...RIFFChunk.getParts("lrgn", regionChunks, true));
+        chunks.push(...RIFFChunk.getParts("lrgn", regionChunks, false, true));
 
         // This will mostly be false as SF2 -> DLS can't have both global and local regions,
         // So it only has global, hence this check.
@@ -200,7 +200,7 @@ export class DownloadableSoundsInstrument
         SpessaLog.groupEnd();
         // This one can explode in length (causing a maximum argument crash),
         // So keep as writeParts, not getParts
-        return RIFFChunk.writeParts("ins ", chunks, true);
+        return RIFFChunk.writeParts("ins ", chunks, false, true);
     }
 
     /**

--- a/src/soundbank/downloadable_sounds/region.ts
+++ b/src/soundbank/downloadable_sounds/region.ts
@@ -183,7 +183,7 @@ export class DownloadableSoundsRegion extends DLSVerifier {
             this.waveLink.write(),
             ...this.articulation.write()
         ];
-        return RIFFChunk.getParts("rgn2", chunks, true);
+        return RIFFChunk.getParts("rgn2", chunks, false, true);
     }
 
     public toSFZone(

--- a/src/soundbank/downloadable_sounds/sample.ts
+++ b/src/soundbank/downloadable_sounds/sample.ts
@@ -162,7 +162,12 @@ export class DownloadableSoundsSample extends DLSVerifier {
             ConsoleColors.value,
             ConsoleColors.recognized
         );
-        return RIFFChunk.getParts("wave", [fmt, wsmp, ...data, info], true);
+        return RIFFChunk.getParts(
+            "wave",
+            [fmt, wsmp, ...data, info],
+            false,
+            true
+        );
     }
 
     private writeFmt() {

--- a/src/soundbank/sound_bank_loader.ts
+++ b/src/soundbank/sound_bank_loader.ts
@@ -11,13 +11,28 @@ export class SoundBankLoader {
      * @returns The loaded sound bank, a BasicSoundBank instance.
      */
     public static fromArrayBuffer(buffer: ArrayBuffer): BasicSoundBank {
-        const check = buffer.slice(8, 12);
-        const a = new IndexedByteArray(check);
-        const id = readBinaryStringIndexed(a, 4).toLowerCase();
+        const riffCheck = buffer.slice(0, 4);
+        const riffText = readBinaryStringIndexed(
+            new IndexedByteArray(riffCheck),
+            4
+        );
+        if (riffText !== "RIFF" && riffText !== "RIFS") {
+            throw new Error(
+                `Expected 'RIFF' or 'RIFS' header, got '${riffText}'`
+            );
+        }
+
+        const rf64 = riffText === "RIFS";
+
+        const check = rf64 ? buffer.slice(12, 16) : buffer.slice(8, 12);
+        const id = readBinaryStringIndexed(
+            new IndexedByteArray(check),
+            4
+        ).toLowerCase();
         if (id === "dls ") {
             return this.loadDLS(buffer);
         }
-        return new SoundFont2(buffer, false);
+        return new SoundFont2(buffer, id === "sfen");
     }
 
     private static loadDLS(buffer: ArrayBuffer) {

--- a/src/soundbank/soundfont/read/soundfont.ts
+++ b/src/soundbank/soundfont/read/soundfont.ts
@@ -47,17 +47,18 @@ export class SoundFont2 extends BasicSoundBank {
             this.parsingError("No data provided!");
         }
 
-        // Read the main chunk
-        const firstChunk = RIFFChunk.read(mainFileArray, false);
-        this.verifyHeader(firstChunk, "riff");
+        // Read RIFF header
+        const fourCC = readBinaryString(mainFileArray, 4).toLowerCase();
+        this.verifyTexts(fourCC, ["riff", "rifs"]);
+        const rf64 = fourCC === "rifs";
+        if (rf64)
+            SpessaLog.info("%cRIFF64 Detected!", ConsoleColors.recognized);
+
+        // Read the main chunk (don't verify as we just did)
+        RIFFChunk.read(mainFileArray, rf64, false);
 
         const type = readBinaryStringIndexed(mainFileArray, 4).toLowerCase();
-        if (type !== "sfbk" && type !== "sfpk") {
-            SpessaLog.groupEnd();
-            throw new SyntaxError(
-                `Invalid soundFont! Expected "sfbk" or "sfpk" got "${type}"`
-            );
-        }
+        this.verifyTexts(type, ["sfbk", "sfpk", "sfen"]);
         /*
         Some SF2Pack description:
         this is essentially sf2, but the entire smpl chunk is compressed (we only support Ogg Vorbis here)
@@ -66,20 +67,15 @@ export class SoundFont2 extends BasicSoundBank {
         const isSF2Pack = type === "sfpk";
 
         // INFO
-        const infoChunk = RIFFChunk.read(mainFileArray);
+        const infoChunk = RIFFChunk.read(mainFileArray, rf64);
         this.verifyHeader(infoChunk, "list");
         const infoString = readBinaryStringIndexed(infoChunk.data, 4);
-        if (infoString !== "INFO") {
-            SpessaLog.groupEnd();
-            throw new SyntaxError(
-                `Invalid soundFont! Expected "INFO" got "${infoString}"`
-            );
-        }
+        this.verifyText(infoString, "info");
 
         let xdtaChunk: RIFFChunk | undefined;
 
         while (infoChunk.data.length > infoChunk.data.currentIndex) {
-            const chunk = RIFFChunk.read(infoChunk.data);
+            const chunk = RIFFChunk.read(infoChunk.data, rf64);
             const text = readBinaryString(chunk.data, chunk.data.length);
             // Special cases
             const headerTyped = chunk.header as SF2InfoFourCC;
@@ -185,25 +181,25 @@ export class SoundFont2 extends BasicSoundBank {
         }> = {};
         if (xdtaChunk !== undefined) {
             // Read the hydra chunks
-            xChunks.phdr = RIFFChunk.read(xdtaChunk.data);
-            xChunks.pbag = RIFFChunk.read(xdtaChunk.data);
-            xChunks.pmod = RIFFChunk.read(xdtaChunk.data);
-            xChunks.pgen = RIFFChunk.read(xdtaChunk.data);
-            xChunks.inst = RIFFChunk.read(xdtaChunk.data);
-            xChunks.ibag = RIFFChunk.read(xdtaChunk.data);
-            xChunks.imod = RIFFChunk.read(xdtaChunk.data);
-            xChunks.igen = RIFFChunk.read(xdtaChunk.data);
-            xChunks.shdr = RIFFChunk.read(xdtaChunk.data);
+            xChunks.phdr = RIFFChunk.read(xdtaChunk.data, rf64);
+            xChunks.pbag = RIFFChunk.read(xdtaChunk.data, rf64);
+            xChunks.pmod = RIFFChunk.read(xdtaChunk.data, rf64);
+            xChunks.pgen = RIFFChunk.read(xdtaChunk.data, rf64);
+            xChunks.inst = RIFFChunk.read(xdtaChunk.data, rf64);
+            xChunks.ibag = RIFFChunk.read(xdtaChunk.data, rf64);
+            xChunks.imod = RIFFChunk.read(xdtaChunk.data, rf64);
+            xChunks.igen = RIFFChunk.read(xdtaChunk.data, rf64);
+            xChunks.shdr = RIFFChunk.read(xdtaChunk.data, rf64);
         }
 
         // SDTA
-        const sdtaChunk = RIFFChunk.read(mainFileArray, false);
+        const sdtaChunk = RIFFChunk.read(mainFileArray, rf64, false);
         this.verifyHeader(sdtaChunk, "list");
         this.verifyText(readBinaryStringIndexed(mainFileArray, 4), "sdta");
 
         // Smpl
         SpessaLog.info("%cVerifying smpl chunk...", ConsoleColors.warn);
-        const sampleDataChunk = RIFFChunk.read(mainFileArray, false);
+        const sampleDataChunk = RIFFChunk.read(mainFileArray, rf64, false);
         this.verifyHeader(sampleDataChunk, "smpl");
         let sampleData: IndexedByteArray | Float32Array;
         // SF2Pack: the entire data is compressed
@@ -216,7 +212,10 @@ export class SoundFont2 extends BasicSoundBank {
                 sampleData = stbvorbis.decode(
                     mainFileArray.buffer.slice(
                         mainFileArray.currentIndex,
-                        mainFileArray.currentIndex + sdtaChunk.size - 12
+                        mainFileArray.currentIndex +
+                            sdtaChunk.size -
+                            4 -
+                            sdtaChunk.headerSize
                     )
                 ).data[0];
             } catch (error) {
@@ -237,44 +236,44 @@ export class SoundFont2 extends BasicSoundBank {
         }
 
         SpessaLog.info(
-            `%cSkipping sample chunk, length: %c${sdtaChunk.size - 12}`,
+            `%cSkipping sample chunk, length: %c${sdtaChunk.size - 4 - sdtaChunk.headerSize}`,
             ConsoleColors.info,
             ConsoleColors.value
         );
-        mainFileArray.currentIndex += sdtaChunk.size - 12;
+        mainFileArray.currentIndex += sdtaChunk.size - 4 - sdtaChunk.headerSize;
 
         // PDTA
         SpessaLog.info("%cLoading preset data chunk...", ConsoleColors.warn);
-        const presetChunk = RIFFChunk.read(mainFileArray);
+        const presetChunk = RIFFChunk.read(mainFileArray, rf64);
         this.verifyHeader(presetChunk, "list");
         readBinaryStringIndexed(presetChunk.data, 4);
 
         // Read the hydra chunks
-        const phdrChunk = RIFFChunk.read(presetChunk.data);
+        const phdrChunk = RIFFChunk.read(presetChunk.data, rf64);
         this.verifyHeader(phdrChunk, "phdr");
 
-        const pbagChunk = RIFFChunk.read(presetChunk.data);
+        const pbagChunk = RIFFChunk.read(presetChunk.data, rf64);
         this.verifyHeader(pbagChunk, "pbag");
 
-        const pmodChunk = RIFFChunk.read(presetChunk.data);
+        const pmodChunk = RIFFChunk.read(presetChunk.data, rf64);
         this.verifyHeader(pmodChunk, "pmod");
 
-        const pgenChunk = RIFFChunk.read(presetChunk.data);
+        const pgenChunk = RIFFChunk.read(presetChunk.data, rf64);
         this.verifyHeader(pgenChunk, "pgen");
 
-        const instChunk = RIFFChunk.read(presetChunk.data);
+        const instChunk = RIFFChunk.read(presetChunk.data, rf64);
         this.verifyHeader(instChunk, "inst");
 
-        const ibagChunk = RIFFChunk.read(presetChunk.data);
+        const ibagChunk = RIFFChunk.read(presetChunk.data, rf64);
         this.verifyHeader(ibagChunk, "ibag");
 
-        const imodChunk = RIFFChunk.read(presetChunk.data);
+        const imodChunk = RIFFChunk.read(presetChunk.data, rf64);
         this.verifyHeader(imodChunk, "imod");
 
-        const igenChunk = RIFFChunk.read(presetChunk.data);
+        const igenChunk = RIFFChunk.read(presetChunk.data, rf64);
         this.verifyHeader(igenChunk, "igen");
 
-        const shdrChunk = RIFFChunk.read(presetChunk.data);
+        const shdrChunk = RIFFChunk.read(presetChunk.data, rf64);
         this.verifyHeader(shdrChunk, "shdr");
 
         SpessaLog.info("%cParsing samples...", ConsoleColors.info);
@@ -439,6 +438,15 @@ export class SoundFont2 extends BasicSoundBank {
             SpessaLog.groupEnd();
             this.parsingError(
                 `Invalid FourCC: Expected "${expected.toLowerCase()}" got "${text.toLowerCase()}"\``
+            );
+        }
+    }
+
+    protected verifyTexts(text: string, expected: string[]) {
+        if (!expected.includes(text.toLowerCase())) {
+            SpessaLog.groupEnd();
+            this.parsingError(
+                `Invalid FourCC: Expected ${expected.map((s) => `"${s}"`).join(", ")} but got "${text.toLowerCase()}"`
             );
         }
     }

--- a/src/soundbank/soundfont/read/soundfont.ts
+++ b/src/soundbank/soundfont/read/soundfont.ts
@@ -33,19 +33,10 @@ export class SoundFont2 extends BasicSoundBank {
     /**
      * Initializes a new SoundFont2 Parser and parses the given data array
      */
-    public constructor(arrayBuffer: ArrayBuffer, warnDeprecated = true) {
-        super("sf2");
-        if (warnDeprecated) {
-            throw new Error(
-                "Using the constructor directly is deprecated. Use SoundBankLoader.fromArrayBuffer() instead."
-            );
-        }
+    public constructor(arrayBuffer: ArrayBuffer, sfe: boolean) {
+        super(sfe ? "sfe" : "sf2");
         const mainFileArray = new IndexedByteArray(arrayBuffer);
         SpessaLog.group("%cParsing a SoundFont2 file...", ConsoleColors.info);
-        if (!mainFileArray) {
-            SpessaLog.groupEnd();
-            this.parsingError("No data provided!");
-        }
 
         // Read RIFF header
         const fourCC = readBinaryString(mainFileArray, 4).toLowerCase();

--- a/src/soundbank/soundfont/write/sdta.ts
+++ b/src/soundbank/soundfont/write/sdta.ts
@@ -17,6 +17,7 @@ export function getSDTA(
     bank: BasicSoundBank,
     smplStartOffsets: number[],
     smplEndOffsets: number[],
+    rf64: boolean,
     progressFunction?: ProgressFunction
 ) {
     // Write smpl: write int16 data of each sample linearly
@@ -49,8 +50,8 @@ export function getSDTA(
         if (!s.isCompressed) sampleData.push(new Uint8Array(92));
     }
 
-    const smpl = RIFFChunk.getParts("smpl", sampleData);
-    const sdta = RIFFChunk.getParts("sdta", smpl, true);
+    const smpl = RIFFChunk.getParts("smpl", sampleData, rf64);
+    const sdta = RIFFChunk.getParts("sdta", smpl, rf64, true);
 
     let offset = 0;
     // Write out

--- a/src/soundbank/soundfont/write/shdr.ts
+++ b/src/soundbank/soundfont/write/shdr.ts
@@ -13,7 +13,8 @@ import type { ExtendedSF2Chunks } from "./types";
 export function getSHDR(
     bank: BasicSoundBank,
     smplStartOffsets: number[],
-    smplEndOffsets: number[]
+    smplEndOffsets: number[],
+    rf64: boolean
 ): ExtendedSF2Chunks {
     const sampleLength = 46;
     const shdrSize = sampleLength * (bank.samples.length + 1); // +1 because EOP
@@ -69,8 +70,8 @@ export function getSHDR(
     // Write EOS and zero everything else
     writeBinaryStringIndexed(shdrData, "EOS", sampleLength);
     writeBinaryStringIndexed(xshdrData, "EOS", sampleLength);
-    const shdr = RIFFChunk.write("shdr", shdrData);
-    const xshdr = RIFFChunk.write("shdr", xshdrData);
+    const shdr = RIFFChunk.write("shdr", shdrData, rf64);
+    const xshdr = RIFFChunk.write("shdr", xshdrData, rf64);
     return {
         pdta: shdr,
         xdta: xshdr

--- a/src/soundbank/soundfont/write/write.ts
+++ b/src/soundbank/soundfont/write/write.ts
@@ -15,7 +15,11 @@ import {
     SPESSASYNTH_DEFAULT_MODULATORS
 } from "../../basic_soundbank/modulator";
 import { fillWithDefaults } from "../../../utils/fill_with_defaults";
-import type { SF2InfoFourCC, SoundFont2WriteOptions } from "../../types";
+import type {
+    SF2InfoFourCC,
+    SFEWriteOptions,
+    SoundFont2WriteOptions
+} from "../../types";
 import type { BasicSoundBank } from "../../basic_soundbank/basic_soundbank";
 import type { ExtendedSF2Chunks } from "./types";
 import { writeSF2Elements } from "./write_sf2_elements";
@@ -24,6 +28,11 @@ import { toISODateString } from "../../../utils/date";
 export const DEFAULT_SF2_WRITE_OPTIONS: SoundFont2WriteOptions = {
     writeDefaultModulators: true,
     writeExtendedLimits: true,
+    software: "SpessaSynth" // ( ͡° ͜ʖ ͡°)
+};
+
+export const DEFAULT_SFE_WRITE_OPTIONS: SFEWriteOptions = {
+    rf64: true,
     software: "SpessaSynth" // ( ͡° ͜ʖ ͡°)
 };
 
@@ -41,6 +50,48 @@ export function writeSF2Internal(
         writeOptions,
         DEFAULT_SF2_WRITE_OPTIONS
     );
+    return writeSF(
+        bank,
+        options.software,
+        options.writeDefaultModulators,
+        options.writeExtendedLimits,
+        false,
+        false
+    );
+}
+
+/**
+ * Writes the sound bank as an SFE 4 file.
+ * @param bank
+ * @param writeOptions the options for writing.
+ * @returns the binary file data.
+ */
+export function writeSFEInternal(
+    bank: BasicSoundBank,
+    writeOptions: Partial<SFEWriteOptions>
+) {
+    const options = fillWithDefaults(writeOptions, DEFAULT_SFE_WRITE_OPTIONS);
+    return writeSF(bank, options.software, true, true, true, true);
+}
+
+/**
+ * General writing function for both SFE and SF2.
+ * @param bank the bank
+ * @param software software param
+ * @param writeDefaultModulators SFE + SF2 compatible
+ * @param writeExtendedLimits SFE + SF2 compatible
+ * @param writeBankLSB SFE Only
+ * @param rf64 SFE Only
+ * @internal
+ */
+function writeSF(
+    bank: BasicSoundBank,
+    software: string,
+    writeDefaultModulators: boolean,
+    writeExtendedLimits: boolean,
+    writeBankLSB: boolean,
+    rf64: boolean
+) {
     SpessaLog.groupCollapsed("%cSaving soundbank...", ConsoleColors.info);
     SpessaLog.group("%cWriting INFO...", ConsoleColors.info);
     /**
@@ -54,7 +105,8 @@ export function writeSF2Internal(
         infoArrays.push(
             ...RIFFChunk.getParts(
                 type,
-                [getStringBytes(data, true, true)] // Pad with zero and ensure even length
+                [getStringBytes(data, true, true)], // Pad with zero and ensure even length
+                rf64
             )
         );
     };
@@ -68,7 +120,7 @@ export function writeSF2Internal(
         const ifilData = new IndexedByteArray(4);
         writeWord(ifilData, info.version.major);
         writeWord(ifilData, info.version.minor);
-        infoArrays.push(RIFFChunk.write("ifil", ifilData));
+        infoArrays.push(RIFFChunk.write("ifil", ifilData, rf64));
     }
     writeSF2Info("isng", info.soundEngine);
     writeSF2Info("INAM", info.name);
@@ -88,7 +140,6 @@ export function writeSF2Internal(
         ? (info?.comment ? info.comment + "\n" : "") + info.subject
         : info?.comment;
     writeSF2Info("ICMT", commentText);
-    const software = options.software;
     writeSF2Info("ISFT", software);
 
     // Do not write unchanged default modulators
@@ -99,7 +150,7 @@ export function writeSF2Internal(
             )
     );
 
-    if (unchangedDefaultModulators && options?.writeDefaultModulators) {
+    if (unchangedDefaultModulators && writeDefaultModulators) {
         const mods = bank.defaultModulators;
         SpessaLog.info(
             `%cWriting %c${mods.length}%c default modulators...`,
@@ -124,24 +175,24 @@ export function writeSF2Internal(
     // Write sdta
     const smplStartOffsets: number[] = [];
     const smplEndOffsets: number[] = [];
-    const sdtaChunk = getSDTA(bank, smplStartOffsets, smplEndOffsets);
+    const sdtaChunk = getSDTA(bank, smplStartOffsets, smplEndOffsets, rf64);
 
     SpessaLog.info("%cWriting PDTA...", ConsoleColors.info);
     // Write pdta
     // Go in reverse so the indexes are correct
     // Instruments
     SpessaLog.info("%cWriting SHDR...", ConsoleColors.info);
-    const shdrChunk = getSHDR(bank, smplStartOffsets, smplEndOffsets);
+    const shdrChunk = getSHDR(bank, smplStartOffsets, smplEndOffsets, rf64);
 
     // Note:
     // https://github.com/spessasus/soundfont-proposals/blob/main/extended_limits.md
 
     SpessaLog.group("%cWriting instruments...", ConsoleColors.info);
-    const instData = writeSF2Elements(bank, false);
+    const instData = writeSF2Elements(bank, rf64, false);
     SpessaLog.groupEnd();
 
     SpessaLog.group("%cWriting presets...", ConsoleColors.info);
-    const presData = writeSF2Elements(bank, true);
+    const presData = writeSF2Elements(bank, rf64, true, writeBankLSB);
     SpessaLog.groupEnd();
 
     const chunks: ExtendedSF2Chunks[] = [
@@ -159,11 +210,12 @@ export function writeSF2Internal(
     const pdtaChunk = RIFFChunk.getParts(
         "pdta",
         chunks.map((c) => c.pdta),
+        rf64,
         true
     );
 
     const writeXdta =
-        options.writeExtendedLimits &&
+        writeExtendedLimits &&
         (instData.writeXdta ||
             presData.writeXdta ||
             bank.presets.some((p) => p.name.length > 20) ||
@@ -181,20 +233,25 @@ export function writeSF2Internal(
             ...RIFFChunk.getParts(
                 "xdta",
                 chunks.map((c) => c.xdta),
+                rf64,
                 true
             )
         );
     }
 
-    const infoChunk = RIFFChunk.getParts("INFO", infoArrays, true);
+    const infoChunk = RIFFChunk.getParts("INFO", infoArrays, rf64, true);
     SpessaLog.info("%cWriting the output file...", ConsoleColors.info);
     // Finally, combine everything
-    const main = RIFFChunk.writeParts("RIFF", [
-        getStringBytes("sfbk"),
-        ...infoChunk,
-        ...sdtaChunk,
-        ...pdtaChunk
-    ]);
+    const main = RIFFChunk.writeParts(
+        rf64 ? "RIFS" : "RIFF",
+        [
+            getStringBytes(writeBankLSB ? "sfen" : "sfbk"),
+            ...infoChunk,
+            ...sdtaChunk,
+            ...pdtaChunk
+        ],
+        rf64
+    );
     SpessaLog.info(
         `%cSaved successfully! Final file size: %c${main.length}`,
         ConsoleColors.info,

--- a/src/soundbank/soundfont/write/write.ts
+++ b/src/soundbank/soundfont/write/write.ts
@@ -129,7 +129,7 @@ function writeSF(
         const ifilData = new IndexedByteArray(4);
         writeWord(ifilData, info.romVersion.major);
         writeWord(ifilData, info.romVersion.minor);
-        infoArrays.push(RIFFChunk.write("iver", ifilData));
+        infoArrays.push(RIFFChunk.write("iver", ifilData, rf64));
     }
     writeSF2Info("ICRD", toISODateString(info.creationDate));
     writeSF2Info("IENG", info.engineer);
@@ -167,7 +167,7 @@ function writeSF(
         // Terminal modulator, is zero
         writeLittleEndianIndexed(dmodData, 0, MOD_BYTE_SIZE);
 
-        infoArrays.push(...RIFFChunk.getParts("DMOD", [dmodData]));
+        infoArrays.push(...RIFFChunk.getParts("DMOD", [dmodData], rf64));
     }
 
     SpessaLog.groupEnd();

--- a/src/soundbank/soundfont/write/write_sf2_elements.ts
+++ b/src/soundbank/soundfont/write/write_sf2_elements.ts
@@ -16,7 +16,10 @@ import { writeWord } from "../../../utils/byte_functions/little_endian";
 
 export function writeSF2Elements(
     bank: BasicSoundBank,
-    isPreset = false
+    rf64: boolean,
+    isPreset: boolean,
+    // Preset only
+    writeBankLSB = false
 ): {
     gen: ExtendedSF2Chunks;
     mod: ExtendedSF2Chunks;
@@ -99,7 +102,8 @@ export function writeSF2Elements(
         xdta: new IndexedByteArray(hdrSize)
     };
 
-    for (const [i, el] of elements.entries()) el.write(hdrData, zoneIndexes[i]);
+    for (const [i, el] of elements.entries())
+        el.write(hdrData, zoneIndexes[i], writeBankLSB);
 
     // Write terminal header records
     if (isPreset) {
@@ -125,28 +129,30 @@ export function writeSF2Elements(
         writeXdta:
             Math.max(currentGenIndex, currentModIndex, zoneIndex) > 0xff_ff,
         gen: {
-            pdta: RIFFChunk.write(genHeader, genData),
+            pdta: RIFFChunk.write(genHeader, genData, rf64),
             // Same as pmod, this chunk includes only the terminal generator record to allow reuse of the pdta parser.
             xdta: RIFFChunk.write(
                 modHeader,
-                new IndexedByteArray(GEN_BYTE_SIZE)
+                new IndexedByteArray(GEN_BYTE_SIZE),
+                rf64
             )
         },
         mod: {
-            pdta: RIFFChunk.write(modHeader, modData),
+            pdta: RIFFChunk.write(modHeader, modData, rf64),
             // This chunk exists solely to preserve parser compatibility and contains only the terminal modulator record.
             xdta: RIFFChunk.write(
                 modHeader,
-                new IndexedByteArray(MOD_BYTE_SIZE)
+                new IndexedByteArray(MOD_BYTE_SIZE),
+                rf64
             )
         },
         bag: {
-            pdta: RIFFChunk.write(bagHeader, bagData.pdta),
-            xdta: RIFFChunk.write(bagHeader, bagData.xdta)
+            pdta: RIFFChunk.write(bagHeader, bagData.pdta, rf64),
+            xdta: RIFFChunk.write(bagHeader, bagData.xdta, rf64)
         },
         hdr: {
-            pdta: RIFFChunk.write(hdrHeader, hdrData.pdta),
-            xdta: RIFFChunk.write(hdrHeader, hdrData.xdta)
+            pdta: RIFFChunk.write(hdrHeader, hdrData.pdta, rf64),
+            xdta: RIFFChunk.write(hdrHeader, hdrData.xdta, rf64)
         }
     };
 }

--- a/src/soundbank/types.ts
+++ b/src/soundbank/types.ts
@@ -266,6 +266,18 @@ export interface SoundFont2WriteOptions extends SoundBankWriteOptions {
  */
 export type DLSWriteOptions = SoundBankWriteOptions;
 
+/**
+ * Options for writing an SFE 4 file.
+ */
+export interface SFEWriteOptions extends SoundBankWriteOptions {
+    /**
+     * If the RIFS (64-bit RIFF chunks) should be used.
+     * Increases maximum size from 4GB to effectively infinite.
+     * Recommended, since SFE 4 is effectively incompatible with SF2.
+     */
+    rf64: boolean;
+}
+
 export interface GenericRange {
     min: number;
     max: number;

--- a/src/utils/byte_functions/little_endian.ts
+++ b/src/utils/byte_functions/little_endian.ts
@@ -94,6 +94,7 @@ export function writeLittleEndianIndexed(
 
 /**
  * Writes a WORD (SHORT)
+ * 16 bits.
  */
 export function writeWord(dataArray: IndexedByteArray, word: number) {
     dataArray[dataArray.currentIndex++] = word & 0xff;
@@ -102,9 +103,21 @@ export function writeWord(dataArray: IndexedByteArray, word: number) {
 
 /**
  * Writes a DWORD (INT)
+ * 32 bits.
  */
 export function writeDword(dataArray: IndexedByteArray, dword: number) {
     writeLittleEndianIndexed(dataArray, dword, 4);
+}
+
+/**
+ * Writes a QWORD (LONG)
+ * 64 bits.
+ */
+export function writeQword(dataArray: IndexedByteArray, qword: number) {
+    const qb = BigInt(qword);
+    for (let i = 0n; i < 8n; i++) {
+        dataArray[dataArray.currentIndex++] = Number((qb >> (i * 8n)) & 0xffn);
+    }
 }
 
 /**

--- a/src/utils/byte_functions/little_endian.ts
+++ b/src/utils/byte_functions/little_endian.ts
@@ -1,6 +1,42 @@
 import type { IndexedByteArray } from "../indexed_array";
 
 /**
+ * Reads the number as little endian from an IndexedByteArray. Uses BigInt to go above 32 bytes.
+ * @param dataArray the array to read from.
+ * @param bytesAmount the number of bytes to read.
+ * @returns the number.
+ */
+export function readLE64Indexed(
+    dataArray: IndexedByteArray,
+    bytesAmount: number
+) {
+    const res = readLE64(dataArray, bytesAmount, dataArray.currentIndex);
+    dataArray.currentIndex += bytesAmount;
+    return res;
+}
+
+/**
+ * Reads the number as little endian. Uses BigInt to go above 32 bytes.
+ * @param dataArray the array to read from.
+ * @param bytesAmount the number of bytes to read.
+ * @param offset the offset to start reading at.
+ * @returns the number.
+ */
+export function readLE64(
+    dataArray: number[] | ArrayLike<number>,
+    bytesAmount: number,
+    offset = 0
+) {
+    let out = 0n;
+
+    for (let i = 0; i < bytesAmount; i++) {
+        out |= BigInt(dataArray[offset + i]) << BigInt(i * 8);
+    }
+
+    return Number(out);
+}
+
+/**
  * Reads the number as little endian from an IndexedByteArray.
  * @param dataArray the array to read from.
  * @param bytesAmount the number of bytes to read.

--- a/src/utils/riff_chunk.ts
+++ b/src/utils/riff_chunk.ts
@@ -1,5 +1,6 @@
 import { IndexedByteArray } from "./indexed_array";
 import {
+    readLE64Indexed,
     readLittleEndianIndexed,
     writeDword
 } from "./byte_functions/little_endian";
@@ -19,7 +20,7 @@ import type {
 
 import type { RMIDInfoFourCC } from "../midi/types";
 
-export type GenericRIFFFourCC = "RIFF" | "LIST" | "INFO";
+export type GenericRIFFFourCC = "RIFF" | "RIFS" | "LIST" | "INFO";
 export type WAVFourCC = "wave" | "cue " | "fmt ";
 export type FourCC =
     | GenericRIFFFourCC
@@ -53,28 +54,42 @@ export class RIFFChunk {
     public readonly data: IndexedByteArray;
 
     /**
+     * The size of the chunk's header in bytes.
+     * This varies for 32-bit and 64-bit RIFF chunks.
+     */
+    public readonly headerSize: number;
+
+    /**
      * Creates a new RIFF chunk.
      */
-    public constructor(header: FourCC, size: number, data: IndexedByteArray) {
+    public constructor(
+        header: FourCC,
+        size: number,
+        data: IndexedByteArray,
+        headerSize = 8
+    ) {
         this.header = header;
         this.size = size;
         this.data = data;
+        this.headerSize = headerSize;
     }
 
     /**
      * Reads a RIFF chunk from an array.
      * @param dataArray the array to read from.
+     * @param rf64 if the chunk uses a 64-bit size.
      * @param readData if the data should be read as well.
-     * @param forceShift if the index should be shifted to the end of the chunk even if the data has not been read.
      */
     public static read(
         dataArray: IndexedByteArray,
-        readData = true,
-        forceShift = false
+        rf64 = false,
+        readData = true
     ): RIFFChunk {
         const header = readBinaryStringIndexed(dataArray, 4) as FourCC;
 
-        let size = readLittleEndianIndexed(dataArray, 4);
+        let size = rf64
+            ? readLE64Indexed(dataArray, 8)
+            : readLittleEndianIndexed(dataArray, 4);
         // @ts-expect-error Not all RIFF files are compliant
         if (header === "") {
             // Safeguard against evil DLS files
@@ -88,14 +103,14 @@ export class RIFFChunk {
                   dataArray.currentIndex + size
               )
             : new IndexedByteArray(0);
-        if (readData || forceShift) {
+        if (readData) {
             dataArray.currentIndex += size;
             if (size % 2 !== 0) {
                 dataArray.currentIndex++;
             }
         }
 
-        return new RIFFChunk(header, size, chunkData);
+        return new RIFFChunk(header, size, chunkData, rf64 ? 12 : 8);
     }
 
     /**

--- a/src/utils/riff_chunk.ts
+++ b/src/utils/riff_chunk.ts
@@ -2,7 +2,8 @@ import { IndexedByteArray } from "./indexed_array";
 import {
     readLE64Indexed,
     readLittleEndianIndexed,
-    writeDword
+    writeDword,
+    writeQword
 } from "./byte_functions/little_endian";
 import {
     getStringBytes,
@@ -117,25 +118,23 @@ export class RIFFChunk {
      * Writes a RIFF chunk correctly.
      * @param header the fourCC code of the header.
      * @param data the binary chunk data.
-     * @param addZeroByte if a zero byte should be at the end of the chunk's data.
      * @param isList if a "LIST" should be set as the chunk type and the actual type should be written at the start of the data.
+     * @param rf64 if the chunk uses a 64-bit size.
      * @returns the binary data.
      */
     public static write(
         header: FourCC,
         data: Uint8Array,
-        addZeroByte = false,
+        rf64 = false,
         isList = false
     ): IndexedByteArray {
         if (header.length !== 4) {
             throw new Error(`Invalid header length: ${header}`);
         }
-        let dataStartOffset = 8;
+        // FourCC + 8 bytes for 64-bit size
+        let dataStartOffset = rf64 ? 12 : 8;
         let headerWritten = header;
-        let dataLength = data.length;
-        if (addZeroByte) {
-            dataLength++;
-        }
+        const dataLength = data.length;
         let writtenSize = dataLength;
         if (isList) {
             // Written header is LIST and the passed header is the first 4 bytes of chunk data
@@ -152,8 +151,11 @@ export class RIFFChunk {
         const outArray = new IndexedByteArray(finalSize);
         // FourCC ("RIFF", "LIST", "pdta" etc.)
         writeBinaryStringIndexed(outArray, headerWritten);
+
         // Chunk size
-        writeDword(outArray, writtenSize);
+        if (rf64) writeQword(outArray, writtenSize);
+        else writeDword(outArray, writtenSize);
+
         if (isList) {
             // List type (e.g. "INFO")
             writeBinaryStringIndexed(outArray, header);
@@ -170,11 +172,13 @@ export class RIFFChunk {
      * @param header  the fourCC code of the header.
      * @param chunks binary chunk data parts, will be combined in order.
      * @param isList if a "LIST" should be set as the chunk type and the actual type should be written at the start of the data.
+     * @param rf64 if the chunk uses a 64-bit size.
      * @returns the chunk as binary blobs.
      */
     public static getParts(
         header: FourCC,
         chunks: Uint8Array[],
+        rf64 = false,
         isList = false
     ) {
         let headerWritten = header;
@@ -184,10 +188,16 @@ export class RIFFChunk {
             totalSize += 4;
             headerWritten = "LIST";
         }
-        const dwordSize = new IndexedByteArray(4);
-        writeDword(dwordSize, totalSize);
+        let sizeBytes: IndexedByteArray;
+        if (rf64) {
+            sizeBytes = new IndexedByteArray(8);
+            writeQword(sizeBytes, totalSize);
+        } else {
+            sizeBytes = new IndexedByteArray(4);
+            writeDword(sizeBytes, totalSize);
+        }
         // Header (LIST or actual header), then size
-        const parts: Uint8Array[] = [getStringBytes(headerWritten), dwordSize];
+        const parts: Uint8Array[] = [getStringBytes(headerWritten), sizeBytes];
 
         // If LIST, the actual chunk "type" is at the beginning of data
         if (isList) parts.push(getStringBytes(header));
@@ -206,14 +216,17 @@ export class RIFFChunk {
      * @param header  the fourCC code of the header.
      * @param chunks binary chunk data parts, will be combined in order.
      * @param isList if a "LIST" should be set as the chunk type and the actual type should be written at the start of the data.
+     * @param rf64 if the chunk uses a 64-bit size.
      * @returns the binary data.
      */
     public static writeParts(
         header: FourCC,
-        chunks: Uint8Array[],
+        chunks: (Uint8Array | number[])[],
+        rf64 = false,
         isList = false
     ): IndexedByteArray {
-        let dataOffset = 8;
+        // FourCC + 8 bytes for 64-bit size
+        let dataOffset = rf64 ? 12 : 8;
         let headerWritten = header;
         const dataLength = chunks.reduce((len, c) => c.length + len, 0);
         let writtenSize = dataLength;
@@ -232,8 +245,11 @@ export class RIFFChunk {
         const outArray = new IndexedByteArray(finalSize);
         // FourCC ("RIFF", "LIST", "pdta" etc.)
         writeBinaryStringIndexed(outArray, headerWritten);
+
         // Chunk size
-        writeDword(outArray, writtenSize);
+        if (rf64) writeQword(outArray, writtenSize);
+        else writeDword(outArray, writtenSize);
+
         if (isList) {
             // List type (e.g. "INFO")
             writeBinaryStringIndexed(outArray, header);

--- a/src/utils/write_wav.ts
+++ b/src/utils/write_wav.ts
@@ -37,33 +37,44 @@ export function audioToWav(
     if (infoOn) {
         const encoder = new TextEncoder();
         const infoChunks = [
-            RIFFChunk.write(
-                "ICMT",
+            RIFFChunk.writeParts("ICMT", [
                 encoder.encode("Created with SpessaSynth"),
-                true
-            )
+                [0]
+            ])
         ];
         if (metadata.artist) {
             infoChunks.push(
-                RIFFChunk.write("IART", encoder.encode(metadata.artist), true)
+                RIFFChunk.writeParts("IART", [
+                    encoder.encode(metadata.artist),
+                    [0]
+                ])
             );
         }
         if (metadata.album) {
             infoChunks.push(
-                RIFFChunk.write("IPRD", encoder.encode(metadata.album), true)
+                RIFFChunk.writeParts("IPRD", [
+                    encoder.encode(metadata.album),
+                    [0]
+                ])
             );
         }
         if (metadata.genre) {
             infoChunks.push(
-                RIFFChunk.write("IGNR", encoder.encode(metadata.genre), true)
+                RIFFChunk.writeParts("IGNR", [
+                    encoder.encode(metadata.genre),
+                    [0]
+                ])
             );
         }
         if (metadata.title) {
             infoChunks.push(
-                RIFFChunk.write("INAM", encoder.encode(metadata.title), true)
+                RIFFChunk.writeParts("INAM", [
+                    encoder.encode(metadata.title),
+                    [0]
+                ])
             );
         }
-        infoChunk = RIFFChunk.writeParts("INFO", infoChunks, true);
+        infoChunk = RIFFChunk.writeParts("INFO", infoChunks, false, true);
     }
 
     // Prepare CUE chunk

--- a/tests/soundbank/rf64_32_test.ts
+++ b/tests/soundbank/rf64_32_test.ts
@@ -1,0 +1,32 @@
+import { BasicSoundBank, SoundBankLoader } from "../../src";
+import fs from "node:fs/promises";
+
+const args = process.argv.slice(2);
+if (args.length !== 2) {
+    console.info("Usage: tsx index.ts <sf2 input path> <sf2 output path>");
+    process.exit();
+}
+
+const sf2In = args[0];
+const sf2Out = args[1];
+
+await BasicSoundBank.isSF3DecoderReady;
+
+const sf2 = await fs.readFile(sf2In);
+const bank = SoundBankLoader.fromArrayBuffer(sf2.buffer);
+console.info("Sound bank type:", bank.type);
+
+// Write as 64 -> parse -> write as 32
+console.info("Convert to sfe64 and parse");
+const bank2 = SoundBankLoader.fromArrayBuffer(
+    bank.writeSFE({
+        software: bank.soundBankInfo.software
+    })
+);
+console.info("Sound bank type 2:", bank2.type);
+console.info("Convert to sf2");
+const bin2 = bank2.writeSF2({
+    software: bank.soundBankInfo.software
+});
+await fs.writeFile(sf2Out, new Uint8Array(bin2));
+console.info(`File written to ${sf2Out}`);

--- a/tests/soundbank/rf64_test.ts
+++ b/tests/soundbank/rf64_test.ts
@@ -1,0 +1,29 @@
+import { BasicSoundBank, SoundBankLoader } from "../../src";
+import fs from "node:fs/promises";
+
+const args = process.argv.slice(2);
+if (args.length !== 2) {
+    console.info("Usage: tsx index.ts <sfe input path> <sfe output path>");
+    process.exit();
+}
+
+const sfeIn = args[0];
+const sfeOut = args[1];
+
+await BasicSoundBank.isSF3DecoderReady;
+
+const sfe = await fs.readFile(sfeIn);
+const bank = SoundBankLoader.fromArrayBuffer(sfe.buffer);
+console.info("Sound bank type:", bank.type);
+
+// Reparse and write again
+const bank2 = SoundBankLoader.fromArrayBuffer(
+    bank.writeSFE({
+        software: bank.soundBankInfo.software
+    })
+);
+const bin2 = bank2.writeSFE({
+    software: bank.soundBankInfo.software
+});
+await fs.writeFile(sfeOut, new Uint8Array(bin2));
+console.info(`File written to ${sfeOut}`);


### PR DESCRIPTION
This PR adds RIFF 64 support to spessasynth_core, as well as write function dedicated to SFE. it only allows RF64 and wBank LSB for now, and has the optional DMOD and XDTA always allowed.

Fixes https://github.com/spessasus/spessasynth_core/issues/101

CC @sylvia-leaf @stgiga