### PR TITLE
Fix voice pool state recycling

### DIFF
--- a/src/synthesizer/audio_engine/voice/voice.ts
+++ b/src/synthesizer/audio_engine/voice/voice.ts
@@ -303,6 +303,12 @@ export class Voice {
         this.overrideReleaseVolEnv = 0;
         this.portamentoDuration = 0;
         this.portamentoFromKey = -1;
+        /* The tuning ratio is only recomputed when the rounded cents change,
+         * so a stale pair left by the previous note on this voice would be
+         * reused as-is whenever the new note rounds to the same cents.
+         */
+        this.tuningCents = 0;
+        this.tuningRatio = 1;
         // Important, these start at 1/4 way there!
         this.vibLfoPhase = 0.25;
         this.modLfoPhase = 0.25;

--- a/src/synthesizer/audio_engine/voice/volume_envelope.ts
+++ b/src/synthesizer/audio_engine/voice/volume_envelope.ts
@@ -230,6 +230,13 @@ export class VolumeEnvelope {
         this.state = 0;
         this.sampleTime = 0;
         this.outputGain = 0;
+        /* Voices are recycled, so the envelope has to start from its initial
+         * values rather than from wherever the previous note left it.
+         */
+        this.attenuationCb = CB_SILENCE;
+        this.releaseStartCb = CB_SILENCE;
+        this.releaseStartTimeSamples = 0;
+        this.releaseDuration = 0;
         this.canEndOnSilentSustain =
             voice.modulatedGenerators[GeneratorTypes.sustainVolEnv] >=
             PERCEIVED_CB_SILENCE;


### PR DESCRIPTION
Currently, voice pool recycling does not reset these state variables, which results in sharp inconsistencies after 8+ and 16+ notes later, at least when testing with Tyroland V30 FIXED FINAL, which has a lot of layers.

This could be a good candidate for the v4-4-0 branch, or I could retarget it on master instead.