### PR TITLE
Emidi extensions

### DIFF
--- a/docs/midi/index.md
+++ b/docs/midi/index.md
@@ -517,6 +517,46 @@ interface InsertionProcessorSnapshot {
 }
 ```
 
+### removeEMIDINonGMTracks
+
+Removes the tracks that EMIDI (Apogee's Extended MIDI) either does not designate as General MIDI, or marks for exclusion by General MIDI
+
+EMIDI marks each track with either one or both of two Track Designation controllers.
+CC#110 indicates one possible device type this track is included for, and may be specified
+more than once for multiple includes. A value of 127 on this control indicates "all devices"
+pass, and this track should be included always. CC#111 indicates one or more possible device
+types which this track should be excluded for. It never specifies the 127 wildcard, because
+that would defeat its purpose.
+
+Following an archived copy of eduke32 source code, the default match type is set to 1, or
+General MIDI. It also looks for the first CC#110 which matches this variable setting, ignoring
+any non-matching values, except for 127, which it also matches. Non-matching values are not
+considered a rejection on CC#110. As for CC#111, it rejects the track if any value set on it
+matches the set device ID, which again is 0 for General MIDI.
+
+The only file where CC#111 seems to have once had a mistaken effect was ALFREDH, which has a
+single track which is excluded by CC#111 value of 0 for General MIDI. However, it also had
+another failure that caught up my own implementation: CC#110 matching values other than the
+original desired filter values of 0 or 127 caused the track to be rejected, and this file
+contains a track which passes values of [0, 2, 9] for inclusion, which broke when a subsequent
+2 and then 9 failed to match the original filter. Thus, all three of the variants of the
+"Crystal" track were dropped incorrectly.
+
+Tracks that carry no designation are left alone, so this is a no-op on a file that is not EMIDI.
+
+This modifies the MIDI sequence _in-place_.
+
+```ts
+const removed = midi.removeEMIDINonGMTracks();
+```
+
+The returned value is a number - the count of tracks that were removed.
+
+!!! Note
+
+    This calls [`flush`](#flush) internally, so the loop points, ports and timeline
+    are recalculated automatically.
+
 ### applySnapshot
 
 Applies a [SynthesizerSnapshot](../spessa-synth-processor/synthesizer-snapshot.md) to the sequence _in place_.

--- a/src/midi/basic_midi.ts
+++ b/src/midi/basic_midi.ts
@@ -41,6 +41,7 @@ import type { SpessaSynthProcessor } from "../synthesizer/processor";
 import { parseRMIDIInternal } from "./read/rmidi";
 import { loadXMF } from "./read/xmf";
 import { applySnapshotInternal } from "./midi_tools/apply_snapshot";
+import { removeEMIDINonGMTracksInternal } from "./midi_tools/emidi";
 
 /**
  * BasicMIDI is the base of a complete MIDI file.
@@ -447,6 +448,24 @@ export class BasicMIDI {
      */
     public modify(opts: Partial<ModifyMIDIOptions>) {
         modifyMIDIInternal(this, opts);
+    }
+
+    // noinspection JSUnusedGlobalSymbols
+    /**
+     * Removes the tracks that EMIDI designates for a device other than
+     * General MIDI.
+     *
+     * An EMIDI song built for several synthesizers carries one copy of its
+     * content per target, each marked with a Track Designation controller,
+     * so playing it as plain General MIDI sounds every copy at once. Tracks
+     * that carry no designation are left alone, so this is a no-op on a file
+     * that is not EMIDI.
+     *
+     * This modifies the MIDI sequence _in-place_.
+     * @returns the number of tracks removed.
+     */
+    public removeEMIDINonGMTracks(): number {
+        return removeEMIDINonGMTracksInternal(this);
     }
 
     // noinspection JSUnusedGlobalSymbols

--- a/src/midi/basic_midi.ts
+++ b/src/midi/basic_midi.ts
@@ -702,6 +702,28 @@ export class BasicMIDI {
         let loopEnd = null;
         let loopType: MIDILoopType = "hard";
 
+        // CC 111 is shared: RPG Maker writes it as a loop start, and Apogee's
+        // Extended MIDI has its own meaning for it. Reading it as a loop point
+        // Is only safe on a file that shows no other sign of being EMIDI, so
+        // Look for the rest of the EMIDI controller block first: 110, and 112
+        // Through 119. 111 itself is deliberately not in that set, since it is
+        // The very thing being disambiguated.
+        const isEMIDI = this.tracks.some((t) =>
+            t.events.some((e) => {
+                if (
+                    (e.statusByte & 0xf0) !==
+                    MIDIMessageTypes.controllerChange
+                ) {
+                    return false;
+                }
+                const cc = e.data[0];
+                return (
+                    cc >= MIDIControllers.undefinedCC112LSB &&
+                    cc <= MIDIControllers.undefinedCC119LSB
+                );
+            })
+        );
+
         for (const track of this.tracks) {
             const usedChannels = new Set<number>();
             let trackHasVoiceMessages = false;
@@ -722,11 +744,18 @@ export class BasicMIDI {
                         case MIDIMessageTypes.controllerChange: {
                             switch (e.data[0]) {
                                 // Touhou
-                                case MIDIControllers.breathController:
+                                case MIDIControllers.breathController: {
+                                    // For Touhou, the data value must be 0.
+                                    if (e.data[1] === 0) loopStart = e.ticks;
+                                    break;
+                                }
                                 // RPG Maker
                                 case MIDIControllers.undefinedCC111LSB: {
-                                    // For Touhou and RPG Maker, the data value must be 0.
-                                    if (e.data[1] === 0) loopStart = e.ticks;
+                                    // For RPG Maker, the data value must be 0.
+                                    // On an EMIDI file this controller is not a loop point.
+                                    if (!isEMIDI && e.data[1] === 0) {
+                                        loopStart = e.ticks;
+                                    }
                                     break;
                                 }
                                 // EMIDI/XMI

--- a/src/midi/midi_tools/emidi.ts
+++ b/src/midi/midi_tools/emidi.ts
@@ -1,0 +1,135 @@
+import { SpessaLog } from "../../utils/loggin";
+import { ConsoleColors } from "../../utils/other";
+import type { BasicMIDI } from "../basic_midi";
+import { MIDIControllers, MIDIMessageTypes } from "../enums";
+import type { MIDITrack } from "../midi_track";
+
+/**
+ * EMIDI (Apogee's Extended MIDI) marks each track with one or more Track
+ * Designation Include and/or Exclude values, naming the synthesizers this
+ * track may either be authored for, or may be excluded for playback on.
+ * A song built for several synths carries one copy of its content per
+ * target, so a player that ignores the designations plays every copy at once.
+ *
+ * Apogee's AudioLib numbers the cards (audiolib/_midi.h): 0 General MIDI,
+ * 1 Roland Sound Canvas, 2 AWE32, 3 Wave Blaster, 4 Sound Blaster,
+ * 5 Pro Audio Spectrum, 6 Sound Man 16, 7 Adlib, 8 Ensoniq Soundscape,
+ * 9 Gravis Ultrasound, and 127 as the wildcard meaning every card. Note
+ * that 0 is a card like any other, not a second wildcard.
+ *
+ * We play as card 0, General MIDI, which is the value eduke32 hardcodes.
+ * The Sound Canvas is a different card, however GM-compatible it is in
+ * practice: counting it as ours too would keep both halves of a Sound
+ * Canvas / General MIDI pair and double the part.
+ *
+ * The two C++ implementations this was ported from — midi_processing
+ * (https://github.com/kode54/midi_processing) and libmidi
+ * (https://github.com/stuerp/libmidi) — instead keep the set {0, 1, 127}
+ * and drop a track on its first designation outside it. That is wrong on
+ * both counts, and drops tracks that should sound: Duke Nukem 3D's
+ * ALFREDH.MID designates "GS Crystal" for cards 0, 2 and 9, so it plays
+ * on ours, but they see card 2 and throw the track away.
+ *
+ * What AudioLib actually does, in _MIDI_InitEMIDI:
+ *
+ *   - a track carrying no designations at all plays;
+ *   - CC 110 include: any one value naming our card carries the track,
+ *     however many other cards it also names. Only if the first
+ *     designation seen is not ours does the track drop, and a later
+ *     matching one takes it back;
+ *   - CC 111 exclude: any value naming our card, or the 127 wildcard,
+ *     drops the track.
+ */
+const EMIDI_INCLUDE_DESIGNATIONS = new Set([0, 127]);
+const EMIDI_EXCLUDE_DESIGNATIONS = new Set([0, 127]);
+
+function isEMIDIEvent(statusByte: number, data: Uint8Array) {
+    return (
+        (statusByte & 0xf0) === MIDIMessageTypes.controllerChange &&
+        data[0] >= MIDIControllers.undefinedCC112LSB &&
+        data[0] <= MIDIControllers.undefinedCC119LSB
+    );
+}
+
+function isTrackInclusion(statusByte: number, data: Uint8Array) {
+    return (
+        (statusByte & 0xf0) === MIDIMessageTypes.controllerChange &&
+        data[0] === MIDIControllers.undefinedCC110LSB
+    );
+}
+
+function isTrackExclusion(statusByte: number, data: Uint8Array) {
+    return (
+        (statusByte & 0xf0) === MIDIMessageTypes.controllerChange &&
+        data[0] === MIDIControllers.undefinedCC111LSB
+    );
+}
+
+/**
+ * Check if any tracks pass EMIDI events. Gates off the filter.
+ */
+function isEMIDITrack(track: MIDITrack) {
+    return track.events.some((e) => isEMIDIEvent(e.statusByte, e.data));
+}
+
+/**
+ * A track plays unless its designations say otherwise: one inclusion naming
+ * our card carries it, an exclusion naming our card drops it, and a track
+ * with no designations at all is left alone.
+ *
+ * This walks the events in order rather than testing inclusions and
+ * exclusions separately, because the two interact: an inclusion that names
+ * us takes back a track an earlier exclusion dropped, and once any
+ * inclusion has had its say a later one naming a different card can no
+ * longer drop the track. Transcribed from _MIDI_InitEMIDI, whose
+ * `IncludeFound` is the flag below. Only run this on EMIDI files.
+ */
+function isGMTrack(track: MIDITrack) {
+    let include = true;
+    let inclusionSeen = false;
+    for (const e of track.events) {
+        if (isTrackInclusion(e.statusByte, e.data)) {
+            if (EMIDI_INCLUDE_DESIGNATIONS.has(e.data[1])) {
+                inclusionSeen = true;
+                include = true;
+            } else if (!inclusionSeen) {
+                inclusionSeen = true;
+                include = false;
+            }
+        } else if (
+            isTrackExclusion(e.statusByte, e.data) &&
+            EMIDI_EXCLUDE_DESIGNATIONS.has(e.data[1])
+        ) {
+            include = false;
+        }
+    }
+    return include;
+}
+
+/**
+ * Removes the tracks that EMIDI either fails to designate for General
+ * MIDI, or designates for exclusion by General MIDI.
+ * @param midi the MIDI to filter, modified in-place.
+ * @returns the number of tracks removed.
+ */
+export function removeEMIDINonGMTracksInternal(midi: BasicMIDI): number {
+    if (!midi.tracks.some((t) => isEMIDITrack(t))) {
+        return 0;
+    }
+    const kept = midi.tracks.filter((t) => isGMTrack(t));
+    const removed = midi.tracks.length - kept.length;
+    if (removed === 0) {
+        return 0;
+    }
+    SpessaLog.info(
+        `%cRemoved %c${removed}%c EMIDI tracks not meant for General MIDI devices.`,
+        ConsoleColors.info,
+        ConsoleColors.recognized,
+        ConsoleColors.info
+    );
+    midi.tracks = kept;
+    // Ports, the timeline and the loop points all derive from the track list.
+    // Recompute them now that the list has changed.
+    midi.flush();
+    return removed;
+}

--- a/tests/midi/emidi_filter_test.ts
+++ b/tests/midi/emidi_filter_test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests the EMIDI non-General-MIDI track filter against a real EMIDI file.
+ *
+ * Duke Nukem 3D's ALFREDH.MID is the sharpest fixture available for the
+ * inclusion side of the filter: a track designated for all cards (127), a
+ * track designated for a list of cards that includes General MIDI but is
+ * mostly other cards ("GS Crystal", CC 110 = 0/2/9), tracks designated only
+ * for other cards, and an undesignated conductor track carrying the tempo
+ * map.
+ *
+ * The expected verdicts are what Apogee's own AudioLib does, read out of
+ * _MIDI_InitEMIDI in eduke32's midi.c:
+ *
+ *   - the player is EMIDI_GeneralMIDI (0); 127 is the all-cards wildcard
+ *   - a track with no CC 110 at all starts included and stays included
+ *   - CC 110 include: any single value naming our card carries the track,
+ *     however many other cards it also names
+ *   - CC 111 exclude: any value naming our card, or 127, drops the track
+ *
+ * The exclusion rule is NOT covered here. ALFREDH.MID does carry CC 111,
+ * on four tracks, but every value names a card that is not ours (4/5/6/7
+ * on "Tremelo", "PizzStrings" and "Glass", 1/3/8 on "GS Effects"), so no
+ * exclusion fires and the expected verdicts below would be unchanged if
+ * the rule were dropped altogether. That holds for every EMIDI file to
+ * hand: across the 32 in this collection, CC 111 only ever names cards
+ * 1 through 9, never card 0 and never the 127 wildcard. A fixture that
+ * exercises exclusion still needs finding.
+ *
+ * Usage:
+ *   tsx tests/midi/emidi_filter_test.ts [midi path]
+ *
+ * Defaults to tests/files/ALFREDH.MID. That file is Duke Nukem 3D game
+ * content and is not redistributable, so it is not in the repo — drop your
+ * own copy into tests/files/, which is ignored.
+ */
+
+import { BasicMIDI } from "../../src";
+import { MIDIControllers, MIDIMessageTypes } from "../../src/midi/enums";
+import type { MIDITrack } from "../../src/midi/midi_track";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+const DEFAULT_MIDI = path.join(
+    import.meta.dirname,
+    "..",
+    "files",
+    "ALFREDH.MID"
+);
+
+/**
+ * The tracks of ALFREDH.MID that AudioLib plays, by their index in the
+ * unfiltered file. Track 0 is the unnamed conductor track: it carries no
+ * designation, so it is included by default — and it holds the tempo map,
+ * the time signatures and the markers.
+ */
+const ALFREDH_EXPECTED_KEPT = [0, 1, 3, 6, 7, 9, 10, 11, 13, 14];
+
+function ccValues(track: MIDITrack, controller: number): number[] {
+    const values = track.events
+        .filter(
+            (e) =>
+                (e.statusByte & 0xf0) === MIDIMessageTypes.controllerChange &&
+                e.data[0] === controller
+        )
+        .map((e) => e.data[1]);
+    return [...new Set(values)];
+}
+
+const midPath = process.argv[2] ?? DEFAULT_MIDI;
+
+let file: Buffer;
+try {
+    file = await fs.readFile(midPath);
+} catch {
+    console.error(`Cannot read ${midPath}.`);
+    console.error(
+        "Pass a path to an EMIDI file, or place ALFREDH.MID in tests/files/."
+    );
+    process.exit(1);
+}
+
+const mid = BasicMIDI.fromArrayBuffer(
+    file.buffer.slice(
+        file.byteOffset,
+        file.byteOffset + file.byteLength
+    ) as ArrayBuffer
+);
+
+// Track identity has to be captured by reference: filtering renumbers the
+// list, and the names do not survive the flush that follows it.
+const original = [...mid.tracks];
+const described = original.map((t) => ({
+    name: t.name || "(conductor)",
+    include: ccValues(t, MIDIControllers.undefinedCC110LSB),
+    exclude: ccValues(t, MIDIControllers.undefinedCC111LSB)
+}));
+const tempoChangesBefore = mid.tempoChanges.length;
+
+console.info(`${path.basename(midPath)}: ${original.length} tracks\n`);
+
+const removed = mid.removeEMIDINonGMTracks();
+const keptIndices = original
+    .map((t, i) => (mid.tracks.includes(t) ? i : -1))
+    .filter((i) => i >= 0);
+
+for (const [i, d] of described.entries()) {
+    const verdict = keptIndices.includes(i) ? "keep" : "DROP";
+    const inc = d.include.length ? `CC110=[${d.include.join(" ")}]` : "";
+    const exc = d.exclude.length ? `CC111=[${d.exclude.join(" ")}]` : "";
+    console.info(
+        `  ${String(i).padStart(2)}  ${verdict}  ${d.name.padEnd(16)} ${inc.padEnd(18)} ${exc}`
+    );
+}
+console.info(
+    `\nremoved ${removed}, kept ${mid.tracks.length}` +
+        `, tempo map ${tempoChangesBefore} -> ${mid.tempoChanges.length} entries`
+);
+
+const failures: string[] = [];
+
+// The filter must never cost the file its tempo map. Dropping an
+// undesignated conductor track silently resets the song to 120 BPM.
+if (mid.tempoChanges.length < tempoChangesBefore) {
+    failures.push(
+        `tempo map lost entries: ${tempoChangesBefore} -> ${mid.tempoChanges.length}`
+    );
+}
+
+if (path.basename(midPath).toUpperCase() === "ALFREDH.MID") {
+    const expected = ALFREDH_EXPECTED_KEPT.join(",");
+    const actual = keptIndices.join(",");
+    if (expected !== actual) {
+        failures.push(`kept tracks [${actual}], AudioLib keeps [${expected}]`);
+        for (const i of ALFREDH_EXPECTED_KEPT) {
+            if (!keptIndices.includes(i)) {
+                failures.push(
+                    `  track ${i} "${described[i].name}" dropped but should play`
+                );
+            }
+        }
+        for (const i of keptIndices) {
+            if (!ALFREDH_EXPECTED_KEPT.includes(i)) {
+                failures.push(
+                    `  track ${i} "${described[i].name}" played but should drop`
+                );
+            }
+        }
+    }
+} else {
+    console.info("\nNo expected track selection for this file; reported only.");
+}
+
+if (failures.length === 0) {
+    console.info("\nPASS");
+    process.exit(0);
+}
+
+console.error("\nFAIL");
+for (const f of failures) {
+    console.error(`  ${f}`);
+}
+process.exit(1);


### PR DESCRIPTION
This gates the RPG Maker CC#111 loop start behind the file not also carrying the rest of the EMIDI controller block (CC#110 and CC#112 through CC#119), which would be a sign of an EMIDI file. CC#111 itself is deliberately excluded from that check, since it is the very controller being disambiguated.

It also adds `BasicMIDI.removeEMIDINonGMTracks()`, which drops the tracks that EMIDI designates for a device other than General MIDI, so a song built for several synthesizers does not play every copy of its content at once. Tracks carrying no designation are left alone, so it is a no-op on a file that is not EMIDI.