### PR TITLE
Do not drop an EFX-assigned channel when effects are disabled

### DIFF
--- a/src/synthesizer/audio_engine/channel/render_voice.ts
+++ b/src/synthesizer/audio_engine/channel/render_voice.ts
@@ -331,15 +331,12 @@ export function renderVoice(
     const gainLeft = panTableLeft[index] * outputGain;
     const gainRight = panTableRight[index] * outputGain;
 
-    // Route into the insertion bus only if it will be processed this block.
-    // Otherwise that buffer is neither cleared nor read.
-    // Losing the channel is not what disabling the effects should mean.
+    // Straight into the insertion EFX, but only if it is active
     if (
         this._midiParameters.efxAssign &&
         systemParameters.effectsEnabled &&
         core.insertionActive
     ) {
-        // Straight into the insertion EFX!
         const insertionL = core.insertionInputL;
         const insertionR = core.insertionInputR;
         for (let i = 0; i < sampleCount; i++) {

--- a/src/synthesizer/audio_engine/channel/render_voice.ts
+++ b/src/synthesizer/audio_engine/channel/render_voice.ts
@@ -331,7 +331,14 @@ export function renderVoice(
     const gainLeft = panTableLeft[index] * outputGain;
     const gainRight = panTableRight[index] * outputGain;
 
-    if (this._midiParameters.efxAssign) {
+    // Route into the insertion bus only if it will be processed this block.
+    // Otherwise that buffer is neither cleared nor read.
+    // Losing the channel is not what disabling the effects should mean.
+    if (
+        this._midiParameters.efxAssign &&
+        systemParameters.effectsEnabled &&
+        core.insertionActive
+    ) {
         // Straight into the insertion EFX!
         const insertionL = core.insertionInputL;
         const insertionR = core.insertionInputR;

--- a/src/synthesizer/audio_engine/synthesizer_core.ts
+++ b/src/synthesizer/audio_engine/synthesizer_core.ts
@@ -245,7 +245,7 @@ export class SynthesizerCore {
     /**
      * Insertion is not used outside SC-88Pro+ MIDIs, this is an optimization.
      */
-    protected insertionActive = false;
+    public insertionActive = false;
     /**
      * For F5 system exclusive.
      */

--- a/src/synthesizer/audio_engine/synthesizer_core.ts
+++ b/src/synthesizer/audio_engine/synthesizer_core.ts
@@ -218,6 +218,10 @@ export class SynthesizerCore {
      */
     public readonly delayProcessor: DelayProcessor;
     /**
+     * Insertion is not used outside SC-88Pro+ MIDIs, this is an optimization.
+     */
+    public insertionActive = false;
+    /**
      * A sysEx may set a "Part" (channel) to receive on a different channel number.
      * This slows down the access, so this toggle tracks if it's enabled or not.
      */
@@ -242,10 +246,6 @@ export class SynthesizerCore {
      * The key is the EFX type stored as MSB << 8 | LSB
      */
     protected readonly insertionEffects = new Map<number, InsertionProcessor>();
-    /**
-     * Insertion is not used outside SC-88Pro+ MIDIs, this is an optimization.
-     */
-    public insertionActive = false;
     /**
      * For F5 system exclusive.
      */


### PR DESCRIPTION
A channel with efxAssign set renders straight into the insertion input buffer.  That buffer is only cleared and only processed inside the `effectsEnabled` block, so with effects disabled the channel was written into a buffer nothing reads and vanished from the output entirely -- and, since the buffer is not cleared in that state either, what it wrote accumulated there until effects were switched back on.

Route into the insertion bus only when it will actually be processed this block, and let the channel mix down normally otherwise.  Disabling the effects should bypass them, not silence the parts that use them.

insertionActive becomes public to allow the check, matching delayActive which already is.

Nothing changes while effects are enabled: every insertion test in tests/midi_file renders bit-identically before and after.